### PR TITLE
Add Siglent VideoTrigger support

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SCOPEHAL_SOURCES
 	SlewRateTrigger.cpp
 	TwoLevelTrigger.cpp
 	UartTrigger.cpp
+	VideoTrigger.cpp
 	WindowTrigger.cpp
 
 	Instrument.cpp

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -3806,7 +3806,7 @@ void SiglentSCPIOscilloscope::PullVideoTrigger()
 		case MODEL_SIGLENT_SDS1000:
 		case MODEL_SIGLENT_SDS2000XE:
 			reply = Trim(converse("TRIG_SELECT?"));
-			// TRSE TV,SR,C1,STAN,<standard>,SYNC,<sync_type>[,LINE,<line>,FLD,<field>]
+			// TV,SR,C1,STAN,<standard>,SYNC,<sync_type>[,LINE,<line>,FLD,<field>]
 			// <standard> := (NTSC|PAL|720P/50|720P/60|1080P/50|1080P/60|1080I/50|1080I/60|CUST)
 			// <sync_type> := (ANY|SELECT)
 			// If <sync_type> is SELECT, then LINE and FLD must be specified
@@ -3816,16 +3816,14 @@ void SiglentSCPIOscilloscope::PullVideoTrigger()
 				char sync_type[128] = "";
 				int line = 1;
 				int field = 1;
-				if (2 >= sscanf(reply.c_str(), "TRSE TV,SR,%127[^,],STAN,%127[^,],SYNC,%127[^,],LINE,%d,FLD,%d", source, standard, sync_type, &line, &field))
+				if (2 >= sscanf(reply.c_str(), "TV,SR,%127[^,],STAN,%127[^,],SYNC,%127[^,],LINE,%d,FLD,%d", source, standard, sync_type, &line, &field))
 				{
 					LogError("Bad TRSE response %s\n", reply.c_str());
 					break;
 				}
 
 				//Level
-				// <trig_source>:TRLV <trig_level>V
-				Unit v(Unit::UNIT_VOLTS);
-				vt->SetLevel(v.ParseString(converse("C1:TRIG_LEVEL?").substr(8)));
+				vt->SetLevel(stof(converse("C1:TRIG_LEVEL?")));
 
 				//Standard
 				string s_standard(standard);

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -40,6 +40,7 @@ class PulseWidthTrigger;
 class RuntTrigger;
 class SlewRateTrigger;
 class UartTrigger;
+class VideoTrigger;
 class WindowTrigger;
 
 /**
@@ -226,6 +227,7 @@ protected:
 	void PullRuntTrigger();
 	void PullSlewRateTrigger();
 	void PullUartTrigger();
+	void PullVideoTrigger();
 	void PullWindowTrigger();
 	void PullTriggerSource(Trigger* trig, std::string triggerModeName);
 
@@ -242,6 +244,7 @@ protected:
 	void PushRuntTrigger(RuntTrigger* trig);
 	void PushSlewRateTrigger(SlewRateTrigger* trig);
 	void PushUartTrigger(UartTrigger* trig);
+	void PushVideoTrigger(VideoTrigger* trig);
 	void PushWindowTrigger(WindowTrigger* trig);
 
 	void BulkCheckChannelEnableState();

--- a/scopehal/VideoTrigger.cpp
+++ b/scopehal/VideoTrigger.cpp
@@ -1,0 +1,116 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#include "scopehal.h"
+#include "VideoTrigger.h"
+#include "LeCroyOscilloscope.h"
+#include "TektronixOscilloscope.h"
+#include "SiglentSCPIOscilloscope.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+VideoTrigger::VideoTrigger(Oscilloscope* scope) : Trigger(scope)
+{
+	CreateInput("din");
+
+	m_standardname = "Standard";
+	m_parameters[m_standardname] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
+	m_parameters[m_standardname].AddEnumValue("NTSC", NTSC);
+	m_parameters[m_standardname].AddEnumValue("PAL", PAL);
+	m_parameters[m_standardname].AddEnumValue("720p50", P720L50);
+	m_parameters[m_standardname].AddEnumValue("720p60", P720L60);
+	m_parameters[m_standardname].AddEnumValue("1080p50", P1080L50);
+	m_parameters[m_standardname].AddEnumValue("1080p60", P1080L60);
+	m_parameters[m_standardname].AddEnumValue("1080i50", I1080L50);
+	m_parameters[m_standardname].AddEnumValue("1080i60", I1080L60);
+	m_parameters[m_standardname].AddEnumValue("Custom", CUSTOM);
+
+	m_syncmode = "Sync Mode";
+	m_parameters[m_syncmode] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
+	m_parameters[m_syncmode].AddEnumValue("Any", ANY);
+	m_parameters[m_syncmode].AddEnumValue("Select", SELECT);
+
+	m_linename = "Line";
+	m_parameters[m_linename] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_COUNTS));
+
+	m_fieldname = "Field";
+	m_parameters[m_fieldname] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_COUNTS));
+
+	m_framerate = "Custom Frame Rate";
+	m_parameters[m_framerate] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
+	m_parameters[m_framerate].AddEnumValue("25Hz", FRAMERATE_25HZ);
+	m_parameters[m_framerate].AddEnumValue("30Hz", FRAMERATE_30HZ);
+	m_parameters[m_framerate].AddEnumValue("50Hz", FRAMERATE_50HZ);
+	m_parameters[m_framerate].AddEnumValue("60Hz", FRAMERATE_60HZ);
+
+	m_interlace = "Custom Interlace";
+	m_parameters[m_interlace] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_COUNTS));
+
+	m_linecount = "Custom Number of Lines";
+	m_parameters[m_linecount] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_COUNTS));
+
+	m_fieldcount = "Custom Number of Fields";
+	m_parameters[m_fieldcount] = FilterParameter(FilterParameter::TYPE_INT, Unit(Unit::UNIT_COUNTS));
+}
+
+VideoTrigger::~VideoTrigger()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Accessors
+
+string VideoTrigger::GetTriggerName()
+{
+	return "Video";
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Input validation
+
+bool VideoTrigger::ValidateChannel(size_t i, StreamDescriptor stream)
+{
+	//We only can take one input
+	if(i > 0)
+		return false;
+
+	//There has to be a signal to trigger on
+	auto schan = dynamic_cast<OscilloscopeChannel*>(stream.m_channel);
+	if(!schan)
+		return false;
+
+	//It has to be from the same instrument we're trying to trigger on
+	if(schan->GetScope() != m_scope)
+		return false;
+
+	return true;
+}

--- a/scopehal/VideoTrigger.h
+++ b/scopehal/VideoTrigger.h
@@ -1,0 +1,138 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Hansem Ro
+	@brief Declaration of VideoTrigger 
+ */
+#ifndef VideoTrigger_h
+#define VideoTrigger_h
+
+/**
+	@brief Trigger when a signal stops toggling for some amount of time
+ */
+class VideoTrigger : public Trigger
+{
+public:
+	VideoTrigger(Oscilloscope* scope);
+	virtual ~VideoTrigger();
+
+	enum StandardType
+	{
+		NTSC,
+		PAL,
+		P720L50,
+		P720L60,
+		P1080L50,
+		P1080L60,
+		I1080L50,
+		I1080L60,
+		CUSTOM
+	};
+
+	void SetStandard(StandardType type)
+	{ m_parameters[m_standardname].SetIntVal(type); }
+
+	StandardType GetStandard()
+	{ return (StandardType) m_parameters[m_standardname].GetIntVal(); }
+
+	enum SyncMode
+	{
+		ANY,
+		SELECT
+	};
+
+	void SetSyncMode(SyncMode mode)
+	{ m_parameters[m_syncmode].SetIntVal(mode); }
+
+	SyncMode GetSyncMode()
+	{ return (SyncMode) m_parameters[m_syncmode].GetIntVal(); }
+
+	void SetLine(int64_t n)
+	{ m_parameters[m_linename].SetIntVal(n); }
+
+	int64_t GetLine()
+	{ return m_parameters[m_linename].GetIntVal(); }
+
+	void SetField(int64_t n)
+	{ m_parameters[m_fieldname].SetIntVal(n); }
+
+	int64_t GetField()
+	{ return m_parameters[m_fieldname].GetIntVal(); }
+
+	enum FrameRate
+	{
+		FRAMERATE_25HZ,
+		FRAMERATE_30HZ,
+		FRAMERATE_50HZ,
+		FRAMERATE_60HZ
+	};
+
+	void SetFrameRate(FrameRate rate)
+	{ m_parameters[m_framerate].SetIntVal(rate); }
+
+	FrameRate GetFrameRate()
+	{ return (FrameRate) m_parameters[m_framerate].GetIntVal(); }
+
+	void SetInterlace(int64_t n)
+	{ m_parameters[m_interlace].SetIntVal(n); }
+
+	int64_t GetInterlace()
+	{ return m_parameters[m_interlace].GetIntVal(); }
+
+	void SetLineCount(int64_t n)
+	{ m_parameters[m_linecount].SetIntVal(n); }
+
+	int64_t GetLineCount()
+	{ return m_parameters[m_linecount].GetIntVal(); }
+
+	void SetFieldCount(int64_t n)
+	{ m_parameters[m_fieldcount].SetIntVal(n); }
+
+	int64_t GetFieldCount()
+	{ return m_parameters[m_fieldcount].GetIntVal(); }
+
+	virtual bool ValidateChannel(size_t i, StreamDescriptor stream);
+
+	static std::string GetTriggerName();
+	TRIGGER_INITPROC(VideoTrigger);
+
+protected:
+	std::string m_standardname;
+	std::string m_syncmode;
+	std::string m_linename;
+	std::string m_fieldname;
+	std::string m_framerate;
+	std::string m_interlace;
+	std::string m_linecount;
+	std::string m_fieldcount;
+};
+
+#endif

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -77,6 +77,7 @@
 #include "RuntTrigger.h"
 #include "SlewRateTrigger.h"
 #include "UartTrigger.h"
+#include "VideoTrigger.h"
 #include "WindowTrigger.h"
 
 #ifndef _WIN32
@@ -229,6 +230,7 @@ void DriverStaticInit()
 	AddTriggerClass(RuntTrigger);
 	AddTriggerClass(SlewRateTrigger);
 	AddTriggerClass(UartTrigger);
+	AddTriggerClass(VideoTrigger);
 	AddTriggerClass(WindowTrigger);
 }
 


### PR DESCRIPTION
Resolves #640.

This adds Video trigger support for several Siglent Oscilloscopes.

Limited testing with SDS2000X Plus only. All I can confirm now is that I am able to configure most video trigger settings via TRIG_SELECT and :TRIGGER:VIDEO SCPI commands. I will leave this in draft state until I can test with actual video signal.