### PR TITLE
Add missing includes masked by PCH

### DIFF
--- a/scopehal/ScopehalUtil.cpp
+++ b/scopehal/ScopehalUtil.cpp
@@ -32,7 +32,8 @@
 	@author Andrew D. Zonenberg
 	@brief Implementation of global utility functions
  */
- #include "ScopehalUtil.h"
+#include "ScopehalUtil.h"
+#include <time.h>
 
 double GetTime()
 {

--- a/scopehal/StandardColors.h
+++ b/scopehal/StandardColors.h
@@ -29,6 +29,7 @@
 
 #ifndef StandardColors_h
 #define StandardColors_h
+#include <string>
 
 namespace StandardColors
 {


### PR DESCRIPTION
Disabling PCH reveals these missing headers.