### PR TITLE
Fix next_pow2 for LLP64 (Windows)

### DIFF
--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -556,11 +556,12 @@ string to_string_hex(uint64_t n, bool zeropad, int len)
  */
 uint64_t next_pow2(uint64_t v)
 {
+//TODO add __lzcnt64 intrinsic for MSVC, handle other platforms if needed
 #ifdef __GNUC__
 	if(v == 1)
 		return 1;
 	else
-		return 1 << (64 - __builtin_clzl(v-1));
+		return 1 << (64 - __builtin_clzll(v-1));
 #else
 	v--;
 	v |= v >> 1;


### PR DESCRIPTION
On Windows, __builtin_clzl() only handles 32-bit inputs due to LLP64. This causes problems when larger values are used. Changing this to __builtin_clzll() fixes the crashes. This most notably fixes the crash when running the demo scope on Windows, as next_pow2() is used in the code that performs the downscaling using FFTS.