### PR TITLE
Support sigcxx 2 and 3 API, and cairomm 1 and 1.16 API

### DIFF
--- a/scopehal/BERT.cpp
+++ b/scopehal/BERT.cpp
@@ -34,9 +34,9 @@ using namespace std;
 
 BERT::BERT()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &BERT::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &BERT::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &BERT::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &BERT::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &BERT::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &BERT::DoPreLoadConfiguration));
 }
 
 BERT::~BERT()

--- a/scopehal/CDRTrigger.h
+++ b/scopehal/CDRTrigger.h
@@ -61,7 +61,7 @@ public:
 	/**
 		@brief Signal emitted every time autobaud is requested
 	 */
-	sigc::signal<void> signal_calculateBitRate()
+	sigc::signal<void()> signal_calculateBitRate()
 	{ return m_calculateBitRateSignal; }
 
 	/**
@@ -122,7 +122,7 @@ protected:
 	std::string m_lecroyEqName;
 	std::string m_polarityName;
 
-	sigc::signal<void> m_calculateBitRateSignal;
+	sigc::signal<void()> m_calculateBitRateSignal;
 };
 
 #endif

--- a/scopehal/CSVStreamInstrument.cpp
+++ b/scopehal/CSVStreamInstrument.cpp
@@ -54,7 +54,7 @@ CSVStreamInstrument::CSVStreamInstrument(SCPITransport* transport)
 		0));
 
 	//needs to run *before* the Oscilloscope class implementation
-	m_preloaders.push_front(sigc::mem_fun(this, &CSVStreamInstrument::DoPreLoadConfiguration));
+	m_preloaders.push_front(sigc::mem_fun(*this, &CSVStreamInstrument::DoPreLoadConfiguration));
 }
 
 CSVStreamInstrument::~CSVStreamInstrument()

--- a/scopehal/EyeMask.cpp
+++ b/scopehal/EyeMask.cpp
@@ -37,6 +37,11 @@
 #include "EyeWaveform.h"
 #include "EyeMask.h"
 
+//WORKAROUND for Cairo >=1.16 support
+#if ((CAIROMM_MAJOR_VERSION == 1) && (CAIROMM_MINOR_VERSION >= 16)) || (CAIROMM_MAJOR_VERSION > 1)
+#define FORMAT_ARGB32 Surface::Format::ARGB32
+#endif
+
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scopehal/Filter.h
+++ b/scopehal/Filter.h
@@ -1074,12 +1074,12 @@ protected:
 #endif
 
 public:
-	sigc::signal<void> signal_outputsChanged()
+	sigc::signal<void()> signal_outputsChanged()
 	{ return m_outputsChangedSignal; }
 
 protected:
 	///@brief Signal emitted when the set of output streams changes
-	sigc::signal<void> m_outputsChangedSignal;
+	sigc::signal<void()> m_outputsChangedSignal;
 
 	/**
 		@brief Instance number (for auto naming)

--- a/scopehal/FilterParameter.h
+++ b/scopehal/FilterParameter.h
@@ -199,13 +199,13 @@ public:
 	/**
 		@brief Signal emitted every time the parameter's value changes
 	 */
-	sigc::signal<void> signal_changed()
+	sigc::signal<void()> signal_changed()
 	{ return m_changeSignal; }
 
 	/**
 		@brief Signal emitted every time the list of enumeration values changes
 	 */
-	sigc::signal<void> signal_enums_changed()
+	sigc::signal<void()> signal_enums_changed()
 	{ return m_enumSignal; }
 
 	/**
@@ -242,8 +242,8 @@ public:
 protected:
 	ParameterTypes				m_type;
 
-	sigc::signal<void>			m_changeSignal;
-	sigc::signal<void>			m_enumSignal;
+	sigc::signal<void()>		m_changeSignal;
+	sigc::signal<void()>		m_enumSignal;
 
 	Unit						m_unit;
 

--- a/scopehal/FlowGraphNode.h
+++ b/scopehal/FlowGraphNode.h
@@ -218,19 +218,19 @@ protected:
 
 public:
 
-	sigc::signal<void> signal_parametersChanged()
+	sigc::signal<void()> signal_parametersChanged()
 	{ return m_parametersChangedSignal; }
 
-	sigc::signal<void> signal_inputsChanged()
+	sigc::signal<void()> signal_inputsChanged()
 	{ return m_inputsChangedSignal; }
 
 protected:
 
 	///@brief Signal emitted when the set of parameters changes
-	sigc::signal<void> m_parametersChangedSignal;
+	sigc::signal<void()> m_parametersChangedSignal;
 
 	///@brief Signal emitted when the set of inputs changes
-	sigc::signal<void> m_inputsChangedSignal;
+	sigc::signal<void()> m_inputsChangedSignal;
 };
 
 #endif

--- a/scopehal/FunctionGenerator.cpp
+++ b/scopehal/FunctionGenerator.cpp
@@ -37,9 +37,9 @@ using namespace std;
 
 FunctionGenerator::FunctionGenerator()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &FunctionGenerator::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &FunctionGenerator::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &FunctionGenerator::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &FunctionGenerator::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &FunctionGenerator::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &FunctionGenerator::DoPreLoadConfiguration));
 }
 
 FunctionGenerator::~FunctionGenerator()

--- a/scopehal/Load.cpp
+++ b/scopehal/Load.cpp
@@ -35,9 +35,9 @@ using namespace std;
 
 Load::Load()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &Load::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &Load::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &Load::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &Load::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &Load::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &Load::DoPreLoadConfiguration));
 }
 
 Load::~Load()

--- a/scopehal/MockOscilloscope.cpp
+++ b/scopehal/MockOscilloscope.cpp
@@ -58,9 +58,9 @@ MockOscilloscope::MockOscilloscope(
 	, m_args(args)
 {
 	//Need to run this loader prior to the main Oscilloscope loader
-	m_loaders.push_front(sigc::mem_fun(this, &MockOscilloscope::DoLoadConfiguration));
+	m_loaders.push_front(sigc::mem_fun(*this, &MockOscilloscope::DoLoadConfiguration));
 
-	m_serializers.push_back(sigc::mem_fun(this, &MockOscilloscope::DoSerializeConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &MockOscilloscope::DoSerializeConfiguration));
 }
 
 MockOscilloscope::~MockOscilloscope()

--- a/scopehal/Multimeter.cpp
+++ b/scopehal/Multimeter.cpp
@@ -34,9 +34,9 @@ using namespace std;
 
 Multimeter::Multimeter()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &Multimeter::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &Multimeter::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &Multimeter::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &Multimeter::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &Multimeter::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &Multimeter::DoPreLoadConfiguration));
 }
 
 Multimeter::~Multimeter()

--- a/scopehal/Oscilloscope.cpp
+++ b/scopehal/Oscilloscope.cpp
@@ -56,9 +56,9 @@ Oscilloscope::Oscilloscope()
 {
 	m_trigger = NULL;
 
-	m_serializers.push_back(sigc::mem_fun(this, &Oscilloscope::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &Oscilloscope::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &Oscilloscope::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &Oscilloscope::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &Oscilloscope::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &Oscilloscope::DoPreLoadConfiguration));
 }
 
 Oscilloscope::~Oscilloscope()

--- a/scopehal/PowerSupply.cpp
+++ b/scopehal/PowerSupply.cpp
@@ -34,9 +34,9 @@ using namespace std;
 
 PowerSupply::PowerSupply()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &PowerSupply::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &PowerSupply::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &PowerSupply::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &PowerSupply::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &PowerSupply::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &PowerSupply::DoPreLoadConfiguration));
 }
 
 PowerSupply::~PowerSupply()

--- a/scopehal/RFSignalGenerator.cpp
+++ b/scopehal/RFSignalGenerator.cpp
@@ -36,9 +36,9 @@ using namespace std;
 
 RFSignalGenerator::RFSignalGenerator()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &RFSignalGenerator::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &RFSignalGenerator::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &RFSignalGenerator::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &RFSignalGenerator::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &RFSignalGenerator::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &RFSignalGenerator::DoPreLoadConfiguration));
 }
 
 RFSignalGenerator::~RFSignalGenerator()

--- a/scopehal/SCPIInstrument.cpp
+++ b/scopehal/SCPIInstrument.cpp
@@ -37,7 +37,7 @@ using namespace std;
 SCPIInstrument::SCPIInstrument(SCPITransport* transport, bool identify)
 	: SCPIDevice(transport, identify)
 {
-	m_serializers.push_back(sigc::mem_fun(this, &SCPIInstrument::DoSerializeConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &SCPIInstrument::DoSerializeConfiguration));
 }
 
 SCPIInstrument::~SCPIInstrument()

--- a/scopehal/SCPISDR.cpp
+++ b/scopehal/SCPISDR.cpp
@@ -39,9 +39,9 @@ SCPISDR::SDRCreateMapType SCPISDR::m_sdrcreateprocs;
 
 SCPISDR::SCPISDR()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &SCPISDR::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &SCPISDR::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &SCPISDR::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &SCPISDR::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &SCPISDR::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &SCPISDR::DoPreLoadConfiguration));
 }
 
 SCPISDR::~SCPISDR()

--- a/scopehal/SCPISpectrometer.cpp
+++ b/scopehal/SCPISpectrometer.cpp
@@ -39,9 +39,9 @@ SCPISpectrometer::SpectrometerCreateMapType SCPISpectrometer::m_spectrometercrea
 
 SCPISpectrometer::SCPISpectrometer()
 {
-	m_serializers.push_back(sigc::mem_fun(this, &SCPISpectrometer::DoSerializeConfiguration));
-	m_loaders.push_back(sigc::mem_fun(this, &SCPISpectrometer::DoLoadConfiguration));
-	m_preloaders.push_back(sigc::mem_fun(this, &SCPISpectrometer::DoPreLoadConfiguration));
+	m_serializers.push_back(sigc::mem_fun(*this, &SCPISpectrometer::DoSerializeConfiguration));
+	m_loaders.push_back(sigc::mem_fun(*this, &SCPISpectrometer::DoLoadConfiguration));
+	m_preloaders.push_back(sigc::mem_fun(*this, &SCPISpectrometer::DoPreLoadConfiguration));
 }
 
 SCPISpectrometer::~SCPISpectrometer()

--- a/scopeprotocols/IBISDriverFilter.cpp
+++ b/scopeprotocols/IBISDriverFilter.cpp
@@ -54,10 +54,10 @@ IBISDriverFilter::IBISDriverFilter(const string& color)
 	m_parameters[m_fname] = FilterParameter(FilterParameter::TYPE_FILENAME, Unit(Unit::UNIT_COUNTS));
 	m_parameters[m_fname].m_fileFilterMask = "*.ibs";
 	m_parameters[m_fname].m_fileFilterName = "IBIS model files (*.ibs)";
-	m_parameters[m_fname].signal_changed().connect(sigc::mem_fun(this, &IBISDriverFilter::OnFnameChanged));
+	m_parameters[m_fname].signal_changed().connect(sigc::mem_fun(*this, &IBISDriverFilter::OnFnameChanged));
 
 	m_parameters[m_modelName] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
-	m_parameters[m_modelName].signal_changed().connect(sigc::mem_fun(this, &IBISDriverFilter::OnModelChanged));
+	m_parameters[m_modelName].signal_changed().connect(sigc::mem_fun(*this, &IBISDriverFilter::OnModelChanged));
 
 	m_parameters[m_cornerName] = FilterParameter(FilterParameter::TYPE_ENUM, Unit(Unit::UNIT_COUNTS));
 	m_parameters[m_cornerName].AddEnumValue("Minimum", CORNER_MIN);


### PR DESCRIPTION
This adds support for the newer sigcxx and cairomm APIs. The old APIs still work.