### PR TITLE
Fix undefined behavior due to casts from float to unsigned int

### DIFF
--- a/scopehal/EyeWaveform.cpp
+++ b/scopehal/EyeWaveform.cpp
@@ -145,8 +145,9 @@ double EyeWaveform::GetBERAtPoint(ssize_t pointx, ssize_t pointy, ssize_t xmid, 
 		int64_t totalhits = innerhits;
 		for(size_t i=len; ; i++)
 		{
-			auto x = static_cast<size_t>(round(xmid + uvecx*i));
-			auto y = static_cast<size_t>(round(ymid + uvecy*i));
+			// must cast through a signed int type to avoid UB [conv.fpint]
+			size_t x = static_cast<ssize_t>(round(xmid + uvecx*i));
+			size_t y = static_cast<ssize_t>(round(ymid + uvecy*i));
 
 			//no lower bounds check since size_t is unsigned
 			//if we go off the low end we'll wrap and fail the high side bounds check

--- a/scopehal/Filter.h
+++ b/scopehal/Filter.h
@@ -610,7 +610,8 @@ public:
 		for(float v : cap->m_samples)
 		{
 			float fbin = (v-low) / delta;
-			size_t bin = floor(fbin * bins);
+			// must cast through a signed int type to avoid UB (e.g. saturates to 0 on arm64) [conv.fpint]
+			size_t bin = static_cast<ssize_t>(floor(fbin * bins));
 			if(bin >= bins)	//negative values wrap to huge positive and get caught here
 				continue;
 			ret[bin] ++;


### PR DESCRIPTION
This currently causes an infinite loop and hang when mousing over eye charts on arm64.