### PR TITLE
Optimize AcceleratorBuffer for unified memory

### DIFF
--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -239,6 +239,7 @@ extern bool g_vulkanDeviceIsAnyMesa;
 extern bool g_vulkanDeviceIsMoltenVK;
 extern uint32_t g_vkPinnedMemoryHeap;
 extern uint32_t g_vkLocalMemoryHeap;
+extern bool g_vulkanDeviceHasUnifiedMemory;
 
 uint32_t GetComputeBlockCount(size_t numGlobal, size_t blockSize);
 


### PR DESCRIPTION
Fixes #681. Tested on M2 MacBook Air. Will test on Intel integrated GPU to observe behavior (Intel GPU may have separately allocated VRAM, so may not utilize this optimization).