### PR TITLE
Work around likely GCC14 bug by disabling Werror for Warray-bounds in one location

### DIFF
--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -1970,7 +1970,15 @@ bool SiglentSCPIOscilloscope::AcquireData()
 					cap->MarkSamplesModifiedFromCpu();
 					ret.push_back(cap);
 				}
+#if (defined(__GNUC__) && !defined(__clang__))
+//WORKAROUND likely GCC bug in newer versions
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Warray-bounds"
+#endif
 				waveforms[i] = ret;
+#if (defined(__GNUC__) && !defined(__clang__))
+#pragma GCC diagnostic pop
+#endif
 			}
 
 			//Save analog waveform data


### PR DESCRIPTION
This warning trips up compile on recent versions of GCC (mainly GCC 14.1), which is current on recent versions of Fedora, Arch Linux, and Windows MSYS2.