### PR TITLE
RigolOscilloscope: add DHO4000 Xorigin support and bandwidth/memory option detection

### DIFF
--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -130,6 +130,7 @@ protected:
 	int m_modelNumber;
 	unsigned int m_bandwidth;
 	bool m_opt200M;
+	bool m_opt500M; /* 500M memory option on DHO4000, option RLU */
 	protocol_version m_protocol;
 
 	void PushEdgeTrigger(EdgeTrigger* trig);


### PR DESCRIPTION
It's possible to ask DHO4000 what the capture time offset was with `:WAVeform:XORigin?`.  There is also `:WAVeform:XREFerence?` but [the manual (page 414)](https://tw.rigol.com/tw/Images/DHO10004000_ProgrammingGuide_EN_tcm17-5395.pdf) says it always returns 0.

While we are in there, it is not possible to know the bandwidth of a DHO4000 only by looking at its model number: you also have to look at the upgrade keys to see if the user has added the bandwidth option -- or if they have [downloaded more RAM](https://downloadmoreram.com/) with the memory depth unlock.  (We currently don't do anything with that, but we might as well make the member variables correct if we can!)