### PR TITLE
Rigol dho highres support

### DIFF
--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -93,6 +93,8 @@ public:
 	virtual bool IsInterleaving() override;
 	virtual bool SetInterleaving(bool combine) override;
 
+	void ForceHDMode(bool mode);
+
 protected:
 	enum protocol_version
 	{
@@ -134,6 +136,9 @@ protected:
 	uint64_t m_maxSrate;  /* Maximum Sample rate for DHO models */
 	bool m_lowSrate;	  /* True for DHO low sample rate models (DHO800/900) */
 	protocol_version m_protocol;
+
+	//True if we have >8 bit capture depth
+	bool m_highDefinition;
 
 	void PushEdgeTrigger(EdgeTrigger* trig);
 	void PullEdgeTrigger();


### PR DESCRIPTION
As requested by joshua_, here is the 16bit data transfert mode for Rigol DHO models.
Tested OK on my DHO804. Should work on DHO1000/4000 as well.
I used the same default/8bit/16bit setting system as for Siglent HD models.
Goes with the companion PR on scopehal-apps for settings.
