### PR TITLE
Modbus + Riden RD and Kuaiqu SPPS PSUs support

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -187,6 +187,7 @@ set(SCOPEHAL_SOURCES
 	RohdeSchwarzHMC8012Multimeter.cpp
 	RohdeSchwarzHMC804xPowerSupply.cpp
 	RidenPowerSupply.cpp
+	KuaiquPowerSupply.cpp
 
 	StandardColors.cpp
 	Filter.cpp

--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -136,6 +136,7 @@ set(SCOPEHAL_SOURCES
 	SCPIBERT.cpp
 	SCPIFunctionGenerator.cpp
 	SCPIInstrument.cpp
+	ModbusInstrument.cpp
 	SCPILoad.cpp
 	SCPIMiscInstrument.cpp
 	SCPIMultimeter.cpp
@@ -185,6 +186,7 @@ set(SCOPEHAL_SOURCES
 	RSRTO6Oscilloscope.cpp
 	RohdeSchwarzHMC8012Multimeter.cpp
 	RohdeSchwarzHMC804xPowerSupply.cpp
+	RidenPowerSupply.cpp
 
 	StandardColors.cpp
 	Filter.cpp

--- a/scopehal/KuaiquPowerSupply.cpp
+++ b/scopehal/KuaiquPowerSupply.cpp
@@ -1,0 +1,274 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#include "scopehal.h"
+#include "KuaiquPowerSupply.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+KuaiquPowerSupply::KuaiquPowerSupply(SCPITransport* transport)
+	: SCPIDevice(transport, false), SCPIInstrument(transport, false)
+{
+	// Only one channel on Kuaiqu PSU
+	m_channels.push_back(new PowerSupplyChannel("CH1", this, "#008000", 0));
+	m_vendor = "Kuaiqu";
+	// Read firmware version number
+	m_fwVersion = SendSimpleCommand(COMMAND_FIRMWARE).substr(3,6);
+	// Model number
+	m_model = "Kuaiqu PSU (" + m_fwVersion + ")";
+	// For some reason, Kuaiqu PSU needs to be in LOCK state in order to return meaningfull current and voltage values
+	SendSimpleCommand(COMMAND_LOCK_ON);
+	// Switch off
+	SendSimpleCommand(COMMAND_OFF);
+	m_on = false;
+	// We have no way to read set values
+	m_current = 0;
+	m_voltage = 0;
+}
+
+KuaiquPowerSupply::~KuaiquPowerSupply()
+{	// Unlock PSI front pannel on exit
+	SendSimpleCommand(COMMAND_LOCK_OFF);
+}
+
+bool KuaiquPowerSupply::SendWriteValueCommand(Command command, double value)
+{
+	char buffer[16];
+	switch (command)
+	{
+		case COMMAND_WRITE_CURRENT:
+		case COMMAND_WRITE_VOLTAGE:
+			{
+				int intValue = (int)value;
+				int fractValue = ((value - intValue)*1000);
+				sprintf(buffer,"<0%c%03d%03d000>",command,intValue,fractValue);
+			}
+			break;
+		default:
+			LogError("Command %c is not a read value command.\n",command);
+			return 0;
+	}
+	std::string commandString(buffer);
+	std::string result = SendCommand(command,commandString);
+	bool success = (result.find("OK") != std::string::npos);
+	if(!success)
+	{
+		LogError("Set value failed, returned '%s'.\n",result.c_str());
+	}
+	return success;
+}
+
+double KuaiquPowerSupply::SendReadValueCommand(Command command)
+{
+	std::string commandString;
+	bool readConstantCurrentState;
+	switch (command)
+	{
+		case COMMAND_READ_VOLTAGE:
+			readConstantCurrentState = false;
+			commandString = "<02000000000>";
+			break;
+		case COMMAND_READ_CURRENT:
+			readConstantCurrentState = true;
+			commandString = "<04000000000>";
+			break;
+		default:
+			LogError("Command %c is not a read value command.\n",command);
+			return 0;
+	}
+	std::string result = SendCommand(command,commandString);
+	if(result.size()>=11)
+	{
+		if(readConstantCurrentState)
+		{
+			m_constantCurrent = result.at(1) == 'C'; 
+		}
+		double floatResult;
+		int intPart = std::stoi(result.substr(3,3));
+		int fractPart = std::stoi(result.substr(6,3));
+		floatResult = intPart + (((double)fractPart)/1000);
+		return floatResult;
+	}
+	else
+	{
+		LogError("Invalid read value return : '%s'\n",result.c_str());
+		return 0;
+	}
+}
+
+std::string KuaiquPowerSupply::SendSimpleCommand(Command command)
+{
+	std::string commandString;
+	switch (command)
+	{
+		case COMMAND_LOCK_ON:
+			commandString = "<09100000000>";
+			break;
+		case COMMAND_LOCK_OFF:
+			commandString = "<09200000000>";
+			break;
+		case COMMAND_FIRMWARE:
+		case COMMAND_ON:
+		case COMMAND_OFF:
+			commandString = "<0";
+			commandString += command;
+			commandString += "000000000>";
+			break;
+		default:
+			LogError("Command %c is not a simple command.\n",command);
+			return "";
+	}
+	return SendCommand(command,commandString);
+}
+
+std::string KuaiquPowerSupply::SendCommand(Command command, std::string commandString)
+{
+	std::string result = "";
+	bool needReply = (command != COMMAND_ON && command != COMMAND_OFF);
+	// Rate limiting
+	this_thread::sleep_until(m_nextCommandReady);
+	m_nextCommandReady = chrono::system_clock::now() + m_rateLimitingInterval;
+	// Lock guard
+	lock_guard<recursive_mutex> lock(m_transportMutex);
+	m_transport->SendCommand(commandString);
+	if(needReply)
+	{
+		char tmp = ' ';
+		while(true)
+		{	// Consume response until we find the end delimiter
+			if(!m_transport->ReadRawData(1,(unsigned char*)&tmp))
+				break;
+			result += tmp;
+			if(tmp == '>')
+				break;
+		}
+	}
+	return result;
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device info
+
+string KuaiquPowerSupply::GetDriverNameInternal()
+{
+	return "kuaiqu_psu";
+}
+
+uint32_t KuaiquPowerSupply::GetInstrumentTypesForChannel(size_t /*i*/) const
+{
+	return INST_PSU;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device capabilities
+
+bool KuaiquPowerSupply::SupportsIndividualOutputSwitching()
+{
+	return true;
+}
+
+bool KuaiquPowerSupply::SupportsVoltageCurrentControl(int chan)
+{
+	return (chan == 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Actual hardware interfacing
+
+bool KuaiquPowerSupply::IsPowerConstantCurrent(int chan)
+{
+	if(chan == 0)
+		return m_constantCurrent;
+	else
+		return false;
+}
+
+double KuaiquPowerSupply::GetPowerVoltageActual(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return SendReadValueCommand(COMMAND_READ_VOLTAGE);
+}
+
+double KuaiquPowerSupply::GetPowerVoltageNominal(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return m_voltage;
+}
+
+double KuaiquPowerSupply::GetPowerCurrentActual(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return SendReadValueCommand(COMMAND_READ_CURRENT);
+}
+
+double KuaiquPowerSupply::GetPowerCurrentNominal(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return m_current;
+}
+
+bool KuaiquPowerSupply::GetPowerChannelActive(int chan)
+{
+	if(chan != 0)
+		return false;
+	return m_on;
+}
+
+void KuaiquPowerSupply::SetPowerVoltage(int chan, double volts)
+{
+	if(chan != 0)
+		return;
+	SendWriteValueCommand(COMMAND_WRITE_VOLTAGE,volts);
+	m_voltage = volts;
+}
+
+void KuaiquPowerSupply::SetPowerCurrent(int chan, double amps)
+{
+	if(chan != 0)
+		return;
+	SendWriteValueCommand(COMMAND_WRITE_CURRENT,amps);
+	m_current = amps;
+}
+
+void KuaiquPowerSupply::SetPowerChannelActive(int chan, bool on)
+{
+	if(chan != 0)
+		return;
+	SendSimpleCommand(on ? COMMAND_ON : COMMAND_OFF);
+	m_on = on;
+}

--- a/scopehal/KuaiquPowerSupply.h
+++ b/scopehal/KuaiquPowerSupply.h
@@ -1,0 +1,101 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#ifndef KuaiquPowerSupply_h
+#define KuaiquPowerSupply_h
+
+/**
+	@brief A KUAIQU power supply
+ */
+class KuaiquPowerSupply
+	: public virtual SCPIPowerSupply
+	, public virtual SCPIInstrument
+{
+public:
+	KuaiquPowerSupply(SCPITransport* transport);
+	virtual ~KuaiquPowerSupply();
+
+	//Device information
+	virtual uint32_t GetInstrumentTypesForChannel(size_t i) const override;
+
+	//Device capabilities
+	virtual bool SupportsIndividualOutputSwitching() override;
+	virtual bool SupportsVoltageCurrentControl(int chan) override;
+
+	//Read sensors
+	virtual double GetPowerVoltageActual(int chan) override;	//actual voltage after current limiting
+	virtual double GetPowerVoltageNominal(int chan) override;	//set point
+	virtual double GetPowerCurrentActual(int chan) override;	//actual current drawn by the load
+	virtual double GetPowerCurrentNominal(int chan) override;	//current limit
+	virtual bool GetPowerChannelActive(int chan) override;
+
+	//Configuration
+	virtual void SetPowerVoltage(int chan, double volts) override;
+	virtual void SetPowerCurrent(int chan, double amps) override;
+	virtual void SetPowerChannelActive(int chan, bool on) override;
+	virtual bool IsPowerConstantCurrent(int chan) override;
+
+protected:
+	enum Command : char {
+		COMMAND_WRITE_VOLTAGE= '1',
+		COMMAND_READ_VOLTAGE = '2',
+		COMMAND_WRITE_CURRENT= '3',
+		COMMAND_READ_CURRENT = '4',
+		COMMAND_KEYPAD_ECHO  = '5',
+		COMMAND_FIRMWARE	 = '6',
+		COMMAND_ON			 = '7', // No reply to off command
+		COMMAND_OFF			 = '8', // No reply to on command
+		COMMAND_LOCK		 = '9',
+		COMMAND_LOCK_ON,
+		COMMAND_LOCK_OFF
+	};
+	// Make sure several request don't collide before we received the corresponding response
+	std::recursive_mutex m_transportMutex;
+	// Rate limiting as per documentation : 3.5 bytes at 9600 bauds = 3.5 * 1.04ms = 3.64ms => 4 ms
+	std::chrono::milliseconds m_rateLimitingInterval = std::chrono::milliseconds(4);
+	std::chrono::system_clock::time_point m_nextCommandReady = std::chrono::system_clock::now();
+
+
+	bool SendWriteValueCommand(Command command, double value);
+	double SendReadValueCommand(Command command);
+	std::string SendSimpleCommand(Command command);
+	std::string SendCommand(Command command, std::string commandString);
+
+	// PSU state
+	bool m_on = false;
+	double m_current = 0;
+	double m_voltage = 0;
+	bool m_constantCurrent = false;
+
+public:
+	static std::string GetDriverNameInternal();
+	POWER_INITPROC(KuaiquPowerSupply);
+};
+
+#endif

--- a/scopehal/ModbusInstrument.cpp
+++ b/scopehal/ModbusInstrument.cpp
@@ -1,0 +1,217 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#include "scopehal.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+ModbusInstrument::ModbusInstrument(SCPITransport* transport, uint8_t slaveAdress)
+	: SCPIInstrument(transport, false)
+{
+	m_slaveAdress = slaveAdress;
+}
+
+ModbusInstrument::~ModbusInstrument()
+{
+
+}
+
+void ModbusInstrument::PushUint16(std::vector<uint8_t>* data, uint16_t value)
+{
+	data->push_back(reinterpret_cast<uint8_t *>(&value)[1]);
+	data->push_back(reinterpret_cast<uint8_t *>(&value)[0]);
+}
+
+uint16_t ModbusInstrument::ReadUint16(std::vector<uint8_t>* data, uint8_t index)
+{
+	if(data->size() <= ((size_t)(index+1)))
+		return 0;
+	return (static_cast<uint16_t>((*data)[index+1]) + (static_cast<uint16_t>((*data)[index]) << 8)); 
+}
+
+void ModbusInstrument::Converse(ModbusFunction function, std::vector<uint8_t>* data)
+{	
+	lock_guard<recursive_mutex> lock(m_modbusMutex);
+	SendCommand (function,data);
+	ReadResponse(function,data);
+}
+
+uint16_t ModbusInstrument::ReadRegister(uint16_t address)
+{
+	std::vector<uint8_t> data;
+	// Adress to read
+	PushUint16(&data,address);
+	// Number of bytes to read (1)
+	PushUint16(&data,0x0001);
+	Converse(ReadAnalogOutputHoldingRegisters,&data);
+	// Response data should be the 2 bytes of the requested register
+	if(data.size()<2)
+	{
+		LogError("Invalid response length: %llu, expected 2.\n",data.size());
+		return 0;
+	}
+	return ReadUint16(&data,0);
+}
+
+uint16_t ModbusInstrument::WriteRegister(uint16_t address, uint16_t value)
+{	
+	std::vector<uint8_t> data;
+	// Adress to write
+	PushUint16(&data,address);
+	// Data to write
+	PushUint16(&data,value);
+	Converse(WriteSingleAnalogOutputRegister,&data);
+	// Response data should be the 4 bytes (2 adress bytes and 2 bytes for the requested register)
+	if(data.size()<4)
+	{
+		LogError("Invalid response length: %llu, expected 4.\n",data.size());
+		return 0;
+	}
+	return ReadUint16(&data,2);
+}
+
+uint8_t ModbusInstrument::ReadRegisters(uint16_t /*address*/, uint8_t* /*data*/, uint8_t /*count*/)
+{
+	// TODO
+	return 0;
+}
+
+
+uint16_t ModbusInstrument::CalculateCRC(const uint8_t *buff, size_t len)
+{
+  static const uint16_t wCRCTable[] = {
+      0X0000, 0XC0C1, 0XC181, 0X0140, 0XC301, 0X03C0, 0X0280, 0XC241, 0XC601,
+      0X06C0, 0X0780, 0XC741, 0X0500, 0XC5C1, 0XC481, 0X0440, 0XCC01, 0X0CC0,
+      0X0D80, 0XCD41, 0X0F00, 0XCFC1, 0XCE81, 0X0E40, 0X0A00, 0XCAC1, 0XCB81,
+      0X0B40, 0XC901, 0X09C0, 0X0880, 0XC841, 0XD801, 0X18C0, 0X1980, 0XD941,
+      0X1B00, 0XDBC1, 0XDA81, 0X1A40, 0X1E00, 0XDEC1, 0XDF81, 0X1F40, 0XDD01,
+      0X1DC0, 0X1C80, 0XDC41, 0X1400, 0XD4C1, 0XD581, 0X1540, 0XD701, 0X17C0,
+      0X1680, 0XD641, 0XD201, 0X12C0, 0X1380, 0XD341, 0X1100, 0XD1C1, 0XD081,
+      0X1040, 0XF001, 0X30C0, 0X3180, 0XF141, 0X3300, 0XF3C1, 0XF281, 0X3240,
+      0X3600, 0XF6C1, 0XF781, 0X3740, 0XF501, 0X35C0, 0X3480, 0XF441, 0X3C00,
+      0XFCC1, 0XFD81, 0X3D40, 0XFF01, 0X3FC0, 0X3E80, 0XFE41, 0XFA01, 0X3AC0,
+      0X3B80, 0XFB41, 0X3900, 0XF9C1, 0XF881, 0X3840, 0X2800, 0XE8C1, 0XE981,
+      0X2940, 0XEB01, 0X2BC0, 0X2A80, 0XEA41, 0XEE01, 0X2EC0, 0X2F80, 0XEF41,
+      0X2D00, 0XEDC1, 0XEC81, 0X2C40, 0XE401, 0X24C0, 0X2580, 0XE541, 0X2700,
+      0XE7C1, 0XE681, 0X2640, 0X2200, 0XE2C1, 0XE381, 0X2340, 0XE101, 0X21C0,
+      0X2080, 0XE041, 0XA001, 0X60C0, 0X6180, 0XA141, 0X6300, 0XA3C1, 0XA281,
+      0X6240, 0X6600, 0XA6C1, 0XA781, 0X6740, 0XA501, 0X65C0, 0X6480, 0XA441,
+      0X6C00, 0XACC1, 0XAD81, 0X6D40, 0XAF01, 0X6FC0, 0X6E80, 0XAE41, 0XAA01,
+      0X6AC0, 0X6B80, 0XAB41, 0X6900, 0XA9C1, 0XA881, 0X6840, 0X7800, 0XB8C1,
+      0XB981, 0X7940, 0XBB01, 0X7BC0, 0X7A80, 0XBA41, 0XBE01, 0X7EC0, 0X7F80,
+      0XBF41, 0X7D00, 0XBDC1, 0XBC81, 0X7C40, 0XB401, 0X74C0, 0X7580, 0XB541,
+      0X7700, 0XB7C1, 0XB681, 0X7640, 0X7200, 0XB2C1, 0XB381, 0X7340, 0XB101,
+      0X71C0, 0X7080, 0XB041, 0X5000, 0X90C1, 0X9181, 0X5140, 0X9301, 0X53C0,
+      0X5280, 0X9241, 0X9601, 0X56C0, 0X5780, 0X9741, 0X5500, 0X95C1, 0X9481,
+      0X5440, 0X9C01, 0X5CC0, 0X5D80, 0X9D41, 0X5F00, 0X9FC1, 0X9E81, 0X5E40,
+      0X5A00, 0X9AC1, 0X9B81, 0X5B40, 0X9901, 0X59C0, 0X5880, 0X9841, 0X8801,
+      0X48C0, 0X4980, 0X8941, 0X4B00, 0X8BC1, 0X8A81, 0X4A40, 0X4E00, 0X8EC1,
+      0X8F81, 0X4F40, 0X8D01, 0X4DC0, 0X4C80, 0X8C41, 0X4400, 0X84C1, 0X8581,
+      0X4540, 0X8701, 0X47C0, 0X4680, 0X8641, 0X8201, 0X42C0, 0X4380, 0X8341,
+      0X4100, 0X81C1, 0X8081, 0X4040};
+
+  uint8_t nTemp;
+  uint16_t wCRCWord = 0xFFFF;
+
+  while (len--) {
+    nTemp = *buff++ ^ wCRCWord;
+    wCRCWord >>= 8;
+    wCRCWord ^= wCRCTable[nTemp];
+  }
+  return wCRCWord;
+}
+
+void ModbusInstrument::SendCommand(ModbusFunction function, std::vector<uint8_t>* data)
+{	// Modbus query frame format is:
+	// | 1 byte slave adress | 1 byte command function # | n bytes of data | 2 bytes CRC |
+	std::vector<unsigned char> buffer;
+	buffer.push_back(m_slaveAdress);
+	buffer.push_back(function);
+	for(size_t i = 0 ; i < data->size() ; i++)
+	{
+		buffer.push_back((unsigned char)(*data)[i]);
+	}
+	uint16_t crc = CalculateCRC(buffer.begin().base(), buffer.size());
+	buffer.push_back(reinterpret_cast<const unsigned char *>(&crc)[0]);
+	buffer.push_back(reinterpret_cast<const unsigned char *>(&crc)[1]);
+	m_transport->SendRawData(buffer.size(),buffer.begin().base());
+}
+
+void ModbusInstrument::ReadResponse(ModbusFunction function, std::vector<uint8_t>* data)
+{	// Modbus response frame format is:
+	// 1/ If functoin is <= 0x04 (read functions):
+	//    | 1 byte slave adress | 1 byte command function # (0x03) | 1 byte data length (n) | n bytes of data | 2 bytes CRC |
+	// 2/ If functoin is >  0x04 (write functions):
+	//    | 1 byte slave adress | 1 byte command function # (0x06) | 2 bytes register adress | 2 bytes register value | 2 bytes CRC |
+	// First read adress, and function
+	std::vector<unsigned char> buffer(2);
+	if(!m_transport->ReadRawData(2,buffer.begin().base()))
+	{
+		LogError("Could not read Modbus slave adress and function response.\n");
+		return;
+	}
+	if(buffer[1]!=function)
+	{
+		LogWarning("Wrong Modbus response function #: %d, expected %d.\n",buffer[1],function);
+	}
+	uint8_t dataLength;
+	if(function <= ReadAnalogInputRegisters)
+	{	// Read data length
+		if(!m_transport->ReadRawData(1,buffer.begin().base()))
+		{
+			LogError("Could not read Modbus data length response.\n");
+			return;
+		}
+		dataLength = buffer[0];
+	}
+	else
+	{	// Data length is fixed (4 bytes)
+		dataLength = 4;
+	}
+	// Read data and CRC
+	buffer.reserve(dataLength);
+	if(!m_transport->ReadRawData(dataLength+2,buffer.begin().base()))
+	{
+		LogError("Could not read Modbus data and CRC response.\n");
+		return;
+	}
+	// TODO check CRC
+	if(data)
+	{	// Move data to result vector
+		data->clear();
+		data->reserve(dataLength);
+		for(int i = 0; i < dataLength ; i++)
+		{
+			data->push_back(buffer[i]);
+		}
+	}
+}

--- a/scopehal/ModbusInstrument.cpp
+++ b/scopehal/ModbusInstrument.cpp
@@ -53,7 +53,7 @@ void ModbusInstrument::PushUint16(std::vector<uint8_t>* data, uint16_t value)
 
 uint16_t ModbusInstrument::ReadUint16(std::vector<uint8_t>* data, uint8_t index)
 {
-	if(data->size() <= ((size_t)(index+1)))
+	if(!data || data->size() <= ((size_t)(index+1)))
 		return 0;
 	return (static_cast<uint16_t>((*data)[index+1]) + (static_cast<uint16_t>((*data)[index]) << 8)); 
 }

--- a/scopehal/ModbusInstrument.h
+++ b/scopehal/ModbusInstrument.h
@@ -1,0 +1,79 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2022 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#ifndef ModbusInstrument_h
+#define ModbusInstrument_h
+
+/**
+	@brief Base class for instruments using Modbus communication protocol
+ */
+class ModbusInstrument 	: public virtual SCPIInstrument
+{
+public:
+	ModbusInstrument(SCPITransport* transport, uint8_t slaveAdress=1);
+	virtual ~ModbusInstrument();
+
+	virtual uint16_t ReadRegister(uint16_t address);
+	virtual uint16_t WriteRegister(uint16_t address, uint16_t value);
+	virtual uint8_t ReadRegisters(uint16_t address, uint8_t* data, uint8_t count);
+
+protected:
+	enum ModbusFunction : uint8_t {
+		// Reading functions
+		ReadDiscreteOutputCoils = 0x01,
+		ReadDiscreteInputContacts = 0x02,
+		ReadAnalogOutputHoldingRegisters = 0x03,
+		ReadAnalogInputRegisters = 0x04,
+
+		// Single write functions
+		WriteSingleDiscreteOutputCoil = 0x05,
+		WriteSingleAnalogOutputRegister = 0x06,
+
+		// Multiple write functions
+		WriteMultipleDiscreteOutputCoils = 0x0F,
+		WriteMultipleAnalogOutputHoldingRegisters = 0x10,
+
+		// User defined
+		Undefined = 0x00
+	};
+
+	// Make sure several request don't collide before we received the corresponding response
+	std::recursive_mutex m_modbusMutex;
+	
+	uint8_t m_slaveAdress;
+	uint16_t CalculateCRC(const uint8_t *buff, size_t len);
+	void Converse(ModbusFunction function, std::vector<uint8_t>* data);
+	void SendCommand(ModbusFunction function, std::vector<uint8_t>* data);
+	void ReadResponse(ModbusFunction function, std::vector<uint8_t>* data);
+	void PushUint16(std::vector<uint8_t>* data, uint16_t value);
+	uint16_t ReadUint16(std::vector<uint8_t>* data, uint8_t index);
+
+};
+
+#endif

--- a/scopehal/ModbusInstrument.h
+++ b/scopehal/ModbusInstrument.h
@@ -41,7 +41,7 @@ public:
 
 	virtual uint16_t ReadRegister(uint16_t address);
 	virtual uint16_t WriteRegister(uint16_t address, uint16_t value);
-	virtual uint8_t ReadRegisters(uint16_t address, uint8_t* data, uint8_t count);
+	virtual uint8_t ReadRegisters(uint16_t address, std::vector<uint16_t>* data, uint8_t count);
 
 protected:
 	enum ModbusFunction : uint8_t {

--- a/scopehal/RidenPowerSupply.cpp
+++ b/scopehal/RidenPowerSupply.cpp
@@ -1,0 +1,169 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#include "scopehal.h"
+#include "RidenPowerSupply.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+RidenPowerSupply::RidenPowerSupply(SCPITransport* transport)
+	: SCPIDevice(transport, false), SCPIInstrument(transport, false), ModbusInstrument(transport)
+{
+	// Only one channel on Ridden PSU
+	m_channels.push_back(new PowerSupplyChannel("CH1", this, "#008000", 0));
+	m_vendor = "Riden";
+	// Read model number
+	uint16_t modelNumber = ReadRegister(0x00);
+	m_model = string("RD") + to_string(modelNumber/10) +"-" + to_string(modelNumber%10);
+	// Read serial number
+	uint16_t seriallNumber = ReadRegister(0x02);
+	m_serial = to_string(seriallNumber);
+	// Read firmware version number
+	float firmwareVersion = ((float)ReadRegister(0x03))/100;
+	m_fwVersion = to_string(firmwareVersion);
+	// Unlock remote command
+
+	// 
+	WriteRegister(0x12,0x01);
+}
+
+RidenPowerSupply::~RidenPowerSupply()
+{
+
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device info
+
+string RidenPowerSupply::GetDriverNameInternal()
+{
+	return "riden_rd";
+}
+
+uint32_t RidenPowerSupply::GetInstrumentTypesForChannel(size_t /*i*/) const
+{
+	return INST_PSU;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device capabilities
+
+bool RidenPowerSupply::SupportsIndividualOutputSwitching()
+{
+	return true;
+}
+
+bool RidenPowerSupply::SupportsVoltageCurrentControl(int chan)
+{
+	return (chan == 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Actual hardware interfacing
+
+/*
+	Bit 0: CH1 CC mode
+	Bit 1: CH2 CC mode
+	Bit 4: CH1 on
+	Bit 5: CH2 on
+ */
+unsigned int RidenPowerSupply::GetStatusRegister()
+{
+	//auto str = m_transport->SendCommandQueuedWithReply("syst:stat?");
+	unsigned int ret = 0;
+	//sscanf(str.c_str(), "0x%x", &ret);
+	return ret;
+}
+
+bool RidenPowerSupply::IsPowerConstantCurrent(int chan)
+{
+	if(chan == 0)
+		return (ReadRegister(0x10)==0x02);
+	else
+		return false;
+}
+
+double RidenPowerSupply::GetPowerVoltageActual(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(0x0A))/100;
+}
+
+double RidenPowerSupply::GetPowerVoltageNominal(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(0x08))/100;
+}
+
+double RidenPowerSupply::GetPowerCurrentActual(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(0x0B))/1000;
+}
+
+double RidenPowerSupply::GetPowerCurrentNominal(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(0x09))/1000;
+}
+
+bool RidenPowerSupply::GetPowerChannelActive(int chan)
+{
+	if(chan != 0)
+		return false;
+	return (ReadRegister(0x12)==0x0001);
+}
+
+void RidenPowerSupply::SetPowerVoltage(int chan, double volts)
+{
+	if(chan != 0)
+		return;
+	WriteRegister(0x08,(uint16_t)(volts*100));
+}
+
+void RidenPowerSupply::SetPowerCurrent(int chan, double amps)
+{
+	if(chan != 0)
+		return;
+	WriteRegister(0x09,(uint16_t)(amps*1000));
+}
+
+void RidenPowerSupply::SetPowerChannelActive(int chan, bool on)
+{
+	if(chan != 0)
+		return;
+	WriteRegister(0x12, (on ? 0x01 : 0x00));
+}

--- a/scopehal/RidenPowerSupply.h
+++ b/scopehal/RidenPowerSupply.h
@@ -1,0 +1,72 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal v0.1                                                                                                     *
+*                                                                                                                      *
+* Copyright (c) 2012-2023 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#ifndef RidenPowerSupply_h
+#define RidenPowerSupply_h
+
+/**
+	@brief A Riden RD6006 power supply or other equivalent model
+ */
+class RidenPowerSupply
+	: public virtual SCPIPowerSupply
+	, public virtual ModbusInstrument
+{
+public:
+	RidenPowerSupply(SCPITransport* transport);
+	virtual ~RidenPowerSupply();
+
+	//Device information
+	virtual uint32_t GetInstrumentTypesForChannel(size_t i) const override;
+
+	//Device capabilities
+	virtual bool SupportsIndividualOutputSwitching() override;
+	virtual bool SupportsVoltageCurrentControl(int chan) override;
+
+	//Read sensors
+	virtual double GetPowerVoltageActual(int chan) override;	//actual voltage after current limiting
+	virtual double GetPowerVoltageNominal(int chan) override;	//set point
+	virtual double GetPowerCurrentActual(int chan) override;	//actual current drawn by the load
+	virtual double GetPowerCurrentNominal(int chan) override;	//current limit
+	virtual bool GetPowerChannelActive(int chan) override;
+
+	//Configuration
+	virtual void SetPowerVoltage(int chan, double volts) override;
+	virtual void SetPowerCurrent(int chan, double amps) override;
+	virtual void SetPowerChannelActive(int chan, bool on) override;
+	virtual bool IsPowerConstantCurrent(int chan) override;
+
+protected:
+	unsigned int GetStatusRegister();
+
+public:
+	static std::string GetDriverNameInternal();
+	POWER_INITPROC(RidenPowerSupply);
+};
+
+#endif

--- a/scopehal/RidenPowerSupply.h
+++ b/scopehal/RidenPowerSupply.h
@@ -62,7 +62,28 @@ public:
 	virtual bool IsPowerConstantCurrent(int chan) override;
 
 protected:
-	unsigned int GetStatusRegister();
+	enum Registers : uint8_t {
+		REGISTER_MODEL    = 0x00,
+		REGISTER_SERIAL   = 0x02,
+		REGISTER_FIRMWARE = 0x03,
+
+		REGISTER_TEMP_C = 0x05,
+		REGISTER_TEMP_F = 0x07,
+
+		REGISTER_V_SET = 0x08,
+		REGISTER_I_SET = 0x09,
+		REGISTER_V_OUT = 0x0A,
+		REGISTER_I_OUT = 0x0B,
+
+		REGISTER_WATT    = 0x0D,
+		REGISTER_V_INPUT = 0x0E,
+		REGISTER_LOCK    = 0x0F,
+		REGISTER_ERROR   = 0x10,
+		
+		REGISTER_ON_OFF  = 0x12
+	};
+
+
 
 public:
 	static std::string GetDriverNameInternal();

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -71,6 +71,7 @@
 #include "RigolDP8xxPowerSupply.h"
 #include "RohdeSchwarzHMC804xPowerSupply.h"
 #include "SiglentPowerSupply.h"
+#include "RidenPowerSupply.h"
 
 #include "SiglentLoad.h"
 
@@ -249,6 +250,7 @@ void DriverStaticInit()
 	AddPowerSupplyDriverClass(RohdeSchwarzHMC804xPowerSupply);
 	AddPowerSupplyDriverClass(SiglentPowerSupply);
 	AddPowerSupplyDriverClass(HP662xAPowerSupply);
+	AddPowerSupplyDriverClass(RidenPowerSupply);
 
 	AddRFSignalGeneratorDriverClass(SiglentVectorSignalGenerator);
 

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -72,6 +72,7 @@
 #include "RohdeSchwarzHMC804xPowerSupply.h"
 #include "SiglentPowerSupply.h"
 #include "RidenPowerSupply.h"
+#include "KuaiquPowerSupply.h"
 
 #include "SiglentLoad.h"
 
@@ -251,6 +252,7 @@ void DriverStaticInit()
 	AddPowerSupplyDriverClass(SiglentPowerSupply);
 	AddPowerSupplyDriverClass(HP662xAPowerSupply);
 	AddPowerSupplyDriverClass(RidenPowerSupply);
+	AddPowerSupplyDriverClass(KuaiquPowerSupply);
 
 	AddRFSignalGeneratorDriverClass(SiglentVectorSignalGenerator);
 

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -146,6 +146,7 @@ extern size_t g_maxComputeGroupCount[3];
 #include "RFSignalGenerator.h"
 #include "RFSignalGeneratorChannel.h"
 #include "SCPIInstrument.h"
+#include "ModbusInstrument.h"
 #include "SCPIBERT.h"
 #include "SCPIFunctionGenerator.h"
 #include "SCPILoad.h"


### PR DESCRIPTION
Hi Andrew,
This PR adds support for Riden PSUs (tested with my RD6006, but should also work with other Riden PSUs).
Modbus protocol handling methods are sitting in the ModbusInstrument class (subclass of SCPIInstrument).
It's a first step for this feature request : https://github.com/ngscopeclient/scopehal-apps/issues/754
Best,
Frederic.