### PR TITLE
Oscilloscope download progress API

### DIFF
--- a/scopehal/DemoOscilloscope.cpp
+++ b/scopehal/DemoOscilloscope.cpp
@@ -575,7 +575,10 @@ bool DemoOscilloscope::AcquireData()
 
 	SequenceSet s;
 	for(int i=0; i<4; i++)
+	{
 		s[GetOscilloscopeChannel(i)] = waveforms[i];
+		this->ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 0.0);
+	}
 
 	//Timestamp the waveform(s)
 	double now = GetTime();

--- a/scopehal/InstrumentChannel.cpp
+++ b/scopehal/InstrumentChannel.cpp
@@ -151,3 +151,21 @@ bool InstrumentChannel::ShouldPersistWaveform()
 	//Default to persisting everything
 	return true;
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Download progress
+
+InstrumentChannel::DownloadState InstrumentChannel::GetDownloadState()
+{
+	return DownloadState::DOWNLOAD_UNKNOWN;
+}
+
+float InstrumentChannel::GetDownloadProgress()
+{
+	return 0.0;
+}
+
+double InstrumentChannel::GetDownloadStartTime()
+{
+	return 0.0;
+}

--- a/scopehal/InstrumentChannel.h
+++ b/scopehal/InstrumentChannel.h
@@ -239,6 +239,32 @@ public:
 		VIS_SHOW,
 	} m_visibilityMode;
 
+	/**
+		@brief Enum values to be mapped to GetDownloadState() int result value for specific channel download states
+	 */
+	enum DownloadState
+	{
+		DOWNLOAD_UNKNOWN,
+		DOWNLOAD_NONE,					///< No download is pending (e.g. the scope is in stop mode)
+		DOWNLOAD_WAITING,				///< This channel is waiting to be downloaded (i.e. scope is triggered but previous channels are currently beeing downloaded)
+		DOWNLOAD_IN_PROGRESS,				///< Download has started
+		DOWNLOAD_FINISHED				///< Download is finished
+	};
+
+	/**
+		@brief Returns the current download state of this channel.
+
+		The returned int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded
+		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
+	 */
+	virtual DownloadState GetDownloadState();
+
+	/// returns the current completion of the download (on the range [0, 1]), if not DOWNLOAD_UNKNOWN
+	virtual float GetDownloadProgress();
+
+	/// returns the start time of a download, if we are DOWNLOAD_IN_PROGRESS; undefined, otherwise
+	virtual double GetDownloadStartTime();
+
 protected:
 
 	virtual void ClearStreams();

--- a/scopehal/LeCroyOscilloscope.h
+++ b/scopehal/LeCroyOscilloscope.h
@@ -352,6 +352,7 @@ protected:
 	//Cached configuration
 	std::map<size_t, float> m_channelVoltageRanges;
 	std::map<size_t, float> m_channelOffsets;
+	std::map<size_t, float> m_channelDigitalThresholds;
 	std::map<size_t, size_t> m_channelNavg;
 	std::map<int, bool> m_channelsEnabled;
 	bool m_sampleRateValid;

--- a/scopehal/Oscilloscope.cpp
+++ b/scopehal/Oscilloscope.cpp
@@ -874,7 +874,7 @@ int Oscilloscope::GetChannelDownloadState(size_t i)
 		{	// We've been downloading for more than 300ms and are not finished yet => show progress bar
 			m_showChannelProgressBar = true;
 			m_downloadSpeedEvaluated = true;
-			LogError("Download speed evaluation done, show progress = true : start time = %f, now = %f, diff = %f, state = %d)\n",m_downloadStartTime, now,now - m_downloadStartTime,result);
+			//LogWarning("Download speed evaluation done, show progress = true : start time = %f, now = %f, diff = %f, state = %d)\n",m_downloadStartTime, now,now - m_downloadStartTime,result);
 		}
 	}
 	if(!m_showChannelProgressBar)
@@ -894,9 +894,11 @@ void Oscilloscope::ChannelsDownloadStarted()
 	if(!m_forceShowChannelProgressBar)
 	{	// Not in force mode => check if the sample depth has changed since last download
 		uint64_t newSampleDepth = GetSampleDepth();
-		if(newSampleDepth != m_downloadSpeedEvalSampleDepth)
+		size_t newEnabledChannels = GetEnabledChannelCount();
+		if((newSampleDepth != m_downloadSpeedEvalSampleDepth) || (newEnabledChannels != m_downloadSpeedEvalEnabledChannels))
 		{	// Sample depth has changed => re-evaluate download speed
 			m_downloadSpeedEvalSampleDepth = newSampleDepth;
+			m_downloadSpeedEvalEnabledChannels = newEnabledChannels;
 			m_downloadSpeedEvaluated = false;
 		}
 		else if(!m_downloadSpeedEvaluated)
@@ -906,7 +908,7 @@ void Oscilloscope::ChannelsDownloadStarted()
 			{	// Download fast enough, no need for a progress bar to be shown
 				m_downloadSpeedEvaluated = true;
 				m_showChannelProgressBar = false;
-				LogError("Download speed evaluation done, show = false : start time = %f, now = %f, diff = %f)\n",m_downloadStartTime, now,now - m_downloadStartTime);
+				//LogWarning("Download speed evaluation done, show = false : start time = %f, now = %f, diff = %f)\n",m_downloadStartTime, now,now - m_downloadStartTime);
 			}
 		}
 	}

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -384,6 +384,63 @@ public:
 	 */
 	virtual bool IsInverted(size_t i);
 
+	/**
+		@brief Gets the download state of the specified channel.
+
+		The returned int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded,
+		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
+
+		@param i Zero-based index of channel
+	 */
+	virtual int GetChannelDownloadState(size_t i);
+
+protected:
+
+	/**
+		@brief Let the driver decide wehther channels download progress should be displayed or not, according to the current sample depth configuration.
+
+		If scope download speed is fast enough according the the currently set sample depth, progress should not be shown to prevent flickering effect on the download bar.
+		
+		If this method is not called by the driver, Oscilloscope class will try and determine whether download progress bar should be shown or not automatically.
+
+		@param show true if the download progress bar should be displayed, false otherwise
+	 */
+	void SetShowChannelsDownloadProgress(bool show);
+
+	/**
+		@brief Drivers should call this method at a download operation start to tell the Oscilloscope class to initialize all channel download states.
+
+	 */
+	void ChannelsDownloadStarted();
+
+	/**
+		@brief Updates the download state for the specified channel.
+
+		The provided int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded
+		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
+
+		@param i Zero-based index of channel
+		@param downloadState the download state value
+
+	 */
+	void UpdateChannelDownloadState(size_t i, int downloadState);
+
+// Handling of waveform downnload operation state
+private:
+	// True when the download progress bar should be displayed (i.e. slow download speed)
+	bool m_showChannelProgressBar = false;
+	// True when the driver is handling download progressbar display state on its side
+	bool m_forceShowChannelProgressBar = false;
+	// Time of start of the latest download operation for this instrument
+	double m_downloadStartTime = 0;
+	// Sample depth that was set on this Oscilloscope the last time the download speed have been evaluated
+	uint64_t m_downloadSpeedEvalSampleDepth = 0;
+	// True whent the download speed has been evaluated
+	bool m_downloadSpeedEvaluated = false;
+	// Dowbload state for each channel of this Oscilloscope
+	std::vector<int> m_channelDownloadStates;
+
+public:
 	//Triggering
 	enum TriggerMode
 	{

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -435,6 +435,8 @@ private:
 	double m_downloadStartTime = 0;
 	// Sample depth that was set on this Oscilloscope the last time the download speed have been evaluated
 	uint64_t m_downloadSpeedEvalSampleDepth = 0;
+	// Number of enabled channels on this Oscilloscope the last time the download speed have been evaluated
+	size_t m_downloadSpeedEvalEnabledChannels;
 	// True whent the download speed has been evaluated
 	bool m_downloadSpeedEvaluated = false;
 	// Dowbload state for each channel of this Oscilloscope

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -384,63 +384,13 @@ public:
 	 */
 	virtual bool IsInverted(size_t i);
 
-	/**
-		@brief Gets the download state of the specified channel.
-
-		The returned int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded,
-		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
-
-		@param i Zero-based index of channel
-	 */
-	virtual int GetChannelDownloadState(size_t i);
-
 protected:
 
-	/**
-		@brief Let the driver decide wehther channels download progress should be displayed or not, according to the current sample depth configuration.
-
-		If scope download speed is fast enough according the the currently set sample depth, progress should not be shown to prevent flickering effect on the download bar.
-		
-		If this method is not called by the driver, Oscilloscope class will try and determine whether download progress bar should be shown or not automatically.
-
-		@param show true if the download progress bar should be displayed, false otherwise
-	 */
-	void SetShowChannelsDownloadProgress(bool show);
-
-	/**
-		@brief Drivers should call this method at a download operation start to tell the Oscilloscope class to initialize all channel download states.
-
-	 */
+	/// @brief Helper method called by drivers to reset all channels to "waiting to download" state.
 	void ChannelsDownloadStarted();
 
-	/**
-		@brief Updates the download state for the specified channel.
-
-		The provided int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded
-		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
-
-		@param i Zero-based index of channel
-		@param downloadState the download state value
-
-	 */
-	void UpdateChannelDownloadState(size_t i, int downloadState);
-
-// Handling of waveform downnload operation state
-private:
-	// True when the download progress bar should be displayed (i.e. slow download speed)
-	bool m_showChannelProgressBar = false;
-	// True when the driver is handling download progressbar display state on its side
-	bool m_forceShowChannelProgressBar = false;
-	// Time of start of the latest download operation for this instrument
-	double m_downloadStartTime = 0;
-	// Sample depth that was set on this Oscilloscope the last time the download speed have been evaluated
-	uint64_t m_downloadSpeedEvalSampleDepth = 0;
-	// Number of enabled channels on this Oscilloscope the last time the download speed have been evaluated
-	size_t m_downloadSpeedEvalEnabledChannels;
-	// True whent the download speed has been evaluated
-	bool m_downloadSpeedEvaluated = false;
-	// Dowbload state for each channel of this Oscilloscope
-	std::vector<int> m_channelDownloadStates;
+	/// @brief Helper method called by drivers to set one channel's download status.
+	void ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::DownloadState state, float progress);
 
 public:
 	//Triggering

--- a/scopehal/OscilloscopeChannel.cpp
+++ b/scopehal/OscilloscopeChannel.cpp
@@ -61,6 +61,9 @@ OscilloscopeChannel::OscilloscopeChannel(
 	Stream::StreamType stype,
 	size_t index)
 	: InstrumentChannel(scope, hwname, color, xunit, yunit, stype, index)
+	, m_downloadState(DownloadState::DOWNLOAD_UNKNOWN)
+	, m_downloadProgress(0.0)
+	, m_downloadStartTime(0.0)
 	, m_refcount(0)
 {
 }
@@ -342,9 +345,17 @@ void OscilloscopeChannel::SetInputMux(size_t select)
 		GetScope()->SetInputMux(m_index, select);
 }
 
-int OscilloscopeChannel::GetDownloadState()
+InstrumentChannel::DownloadState OscilloscopeChannel::GetDownloadState()
 {
-	if(m_instrument)
-		return GetScope()->GetChannelDownloadState(m_index);
-	return DownloadState::DOWNLOAD_PROGRESS_DISABLED;
+	return m_downloadState;
+}
+
+float OscilloscopeChannel::GetDownloadProgress()
+{
+	return m_downloadProgress;
+}
+
+double OscilloscopeChannel::GetDownloadStartTime()
+{
+	return m_downloadStartTime;
 }

--- a/scopehal/OscilloscopeChannel.cpp
+++ b/scopehal/OscilloscopeChannel.cpp
@@ -341,3 +341,10 @@ void OscilloscopeChannel::SetInputMux(size_t select)
 	if(m_instrument)
 		GetScope()->SetInputMux(m_index, select);
 }
+
+int OscilloscopeChannel::GetDownloadState()
+{
+	if(m_instrument)
+		return GetScope()->GetChannelDownloadState(m_index);
+	return DownloadState::DOWNLOAD_PROGRESS_DISABLED;
+}

--- a/scopehal/OscilloscopeChannel.h
+++ b/scopehal/OscilloscopeChannel.h
@@ -145,6 +145,28 @@ public:
 	virtual void SetInputMux(size_t select);
 
 	void SetDefaultDisplayName();
+
+
+	/**
+		@brief Enum values to be mapped to GetDownloadState() int result value for specific channel download states
+	 */
+	enum DownloadState : int 
+	{
+		DOWNLOAD_PROGRESS_DISABLED = -3, 	// Tell the UI not to show a download progress bar (e.g. if downloading the whole waveform is fast enough)
+		DOWNLOAD_NONE = -2,					// No download is pending (e.g. the scope is in stop mode)
+		DOWNLOAD_WAITING = -1,				// This channel is waiting to be downloaded (i.e. scope is triggered but previous channels are currently beeing downloaded)
+		DOWNLOAD_STARTED = 0,				// Download as tarted
+		DOWNLOAD_FINISHED = 100				// Download is finished
+	};
+
+	/**
+		@brief Returns the current download state of this channel.
+
+		The returned int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded
+		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
+	 */
+	int GetDownloadState();
+
 protected:
 	void SharedCtorInit(Unit unit);
 

--- a/scopehal/OscilloscopeChannel.h
+++ b/scopehal/OscilloscopeChannel.h
@@ -146,26 +146,15 @@ public:
 
 	void SetDefaultDisplayName();
 
+	virtual DownloadState GetDownloadState() override;
+	virtual float GetDownloadProgress() override;
+	virtual double GetDownloadStartTime() override;
 
-	/**
-		@brief Enum values to be mapped to GetDownloadState() int result value for specific channel download states
-	 */
-	enum DownloadState : int 
-	{
-		DOWNLOAD_PROGRESS_DISABLED = -3, 	// Tell the UI not to show a download progress bar (e.g. if downloading the whole waveform is fast enough)
-		DOWNLOAD_NONE = -2,					// No download is pending (e.g. the scope is in stop mode)
-		DOWNLOAD_WAITING = -1,				// This channel is waiting to be downloaded (i.e. scope is triggered but previous channels are currently beeing downloaded)
-		DOWNLOAD_STARTED = 0,				// Download as tarted
-		DOWNLOAD_FINISHED = 100				// Download is finished
-	};
-
-	/**
-		@brief Returns the current download state of this channel.
-
-		The returned int value can either be an integer ranging from 0 to 100 corresponding to the percentage of the waveform that has already been downloaded
-		or a (negative) int value to be mapped to the OscilloscopeChannel::DownloadState enum
-	 */
-	int GetDownloadState();
+private:
+	// to be accessed by Oscilloscope to update download status
+	DownloadState m_downloadState;
+	float m_downloadProgress;
+	double m_downloadStartTime;
 
 protected:
 	void SharedCtorInit(Unit unit);

--- a/scopehal/RSRTO6Oscilloscope.h
+++ b/scopehal/RSRTO6Oscilloscope.h
@@ -161,6 +161,7 @@ protected:
 	std::map<size_t, float> m_channelOffsets;
 	std::map<size_t, float> m_channelVoltageRanges;
 	std::map<int, bool> m_channelsEnabled;
+	std::map<size_t, float> m_channelDigitalThresholds;
 	std::map<size_t, OscilloscopeChannel::CouplingType> m_channelCouplings;
 	std::map<size_t, int> m_channelBandwidthLimits;
 	std::map<size_t, double> m_channelAttenuations;

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1001,6 +1001,10 @@ bool RigolOscilloscope::AcquireData()
 	//Clean up
 	delete[] temp_buf;
 
+	// Everything is done, and nothing else has anything in its buffer anymore.
+	for(size_t i = 0; i < m_analogChannelCount; i++)
+		ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
+
 	//TODO: support digital channels
 
 	//Re-arm the trigger if not in one-shot mode

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -858,10 +858,7 @@ bool RigolOscilloscope::AcquireData()
 		cap->m_startTimestamp = floor(now);
 		cap->m_startFemtoseconds = (now - floor(now)) * FS_PER_SECOND;
 
-		// Determine the size of one percent of the data to be downloaded
-		int percent = (m_highDefinition ? 2* npoints : npoints)/100;
-		int percentage = 0;
-		int restPercentage = 0;
+		ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, 0.0);
 
 		//Downloading the waveform is a pain in the butt, because we can only pull 250K points at a time! (Unless you have a MSO5)
 		for(size_t npoint = 0; npoint < npoints;)
@@ -942,28 +939,14 @@ bool RigolOscilloscope::AcquireData()
 			//Read actual block content and decode it
 			//Scale: (value - Yorigin - Yref) * Yinc
 
-			// Read it in slice so that we can smoothly update download progress bar
 			size_t bytesToRead = header_blocksize_bytes + 1; //trailing newline after data block
-			int slices = bytesToRead / percent;
-			int sliceRest = bytesToRead % percent;
-			size_t bytesRead = 0;
-			for(int s = 0 ; s < slices ; s++)
-			{	// Read each block corresponding to one percent of the total waveform
-				bytesRead += m_transport->ReadRawData(percent, (temp_buf+bytesRead));
-				percentage++;
-				UpdateChannelDownloadState(i,percentage);
-			}
-			if(bytesRead < bytesToRead)
-			{	// For the rest (bytesToRead % slices)
-				m_transport->ReadRawData(bytesToRead-bytesRead, (temp_buf+bytesRead));
-				restPercentage += sliceRest;
-				if(restPercentage>=percent && percentage < OscilloscopeChannel::DownloadState::DOWNLOAD_FINISHED)
-				{	// Accumulate leftover bytes untill we get a whole percent
-					percentage++;
-					UpdateChannelDownloadState(i,percentage);
-					restPercentage = 0;
-				}
-			}
+			auto downloadCallback = [i, this, npoint, npoints, bytesToRead] (float progress) {
+				/* we get the percentage of this particular download; convert this into linear percentage across all chunks */
+				float bytes_progress = npoint * (m_highDefinition ? 2 : 1) + progress * bytesToRead;
+				float bytes_total = npoints * (m_highDefinition ? 2 : 1);
+				ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, bytes_progress / bytes_total);
+			};
+			m_transport->ReadRawData(bytesToRead, temp_buf, downloadCallback);
 
 			double ydelta = yorigin + yreference;
 			cap->Resize(cap->m_samples.size() + header_blocksize);
@@ -993,7 +976,7 @@ bool RigolOscilloscope::AcquireData()
 			npoint += header_blocksize;
 		}
 		// Notify about end of download for this channel
-		UpdateChannelDownloadState(i,OscilloscopeChannel::DownloadState::DOWNLOAD_FINISHED);
+		ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_FINISHED, 1.0);
 
 		//Done, update the data
 		if(cap)

--- a/scopehal/SCPILinuxGPIBTransport.cpp
+++ b/scopehal/SCPILinuxGPIBTransport.cpp
@@ -146,7 +146,7 @@ void SCPILinuxGPIBTransport::SendRawData(size_t len, const unsigned char* buf)
 	ibwrt(m_handle, (const char *)buf, len);
 }
 
-size_t SCPILinuxGPIBTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t SCPILinuxGPIBTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	if (!IsConnected())
 		return 0;

--- a/scopehal/SCPILinuxGPIBTransport.h
+++ b/scopehal/SCPILinuxGPIBTransport.h
@@ -56,7 +56,7 @@ public:
 	void FlushRXBuffer(void) override;
 	bool SendCommand(const std::string& cmd) override;
 	std::string ReadReply(bool endOnSemicolon = true) override;
-	size_t ReadRawData(size_t len, unsigned char* buf) override;
+	size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	void SendRawData(size_t len, const unsigned char* buf) override;
 
 	bool IsCommandBatchingSupported() override;

--- a/scopehal/SCPILxiTransport.cpp
+++ b/scopehal/SCPILxiTransport.cpp
@@ -173,7 +173,7 @@ void SCPILxiTransport::SendRawData(size_t len, const unsigned char* buf)
 	lxi_send(m_device, const_cast<char*>(reinterpret_cast<const char*>(buf)), len, m_timeout);
 }
 
-size_t SCPILxiTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t SCPILxiTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	// Data in the staging buffer is assumed to always be a consequence of a SendCommand request.
 	// Since we fetch all the reply data in one go, once all this data has been fetched, we mark

--- a/scopehal/SCPILxiTransport.h
+++ b/scopehal/SCPILxiTransport.h
@@ -56,7 +56,7 @@ public:
 
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	virtual bool IsCommandBatchingSupported() override;

--- a/scopehal/SCPINullTransport.cpp
+++ b/scopehal/SCPINullTransport.cpp
@@ -86,7 +86,7 @@ void SCPINullTransport::SendRawData(size_t /*len*/, const unsigned char* /*buf*/
 {
 }
 
-size_t SCPINullTransport::ReadRawData(size_t /*len*/, unsigned char* /*buf*/)
+size_t SCPINullTransport::ReadRawData(size_t /*len*/, unsigned char* /*buf*/, std::function<void(float)> /*progress*/)
 {
 	return 0;
 }

--- a/scopehal/SCPINullTransport.h
+++ b/scopehal/SCPINullTransport.h
@@ -50,7 +50,7 @@ public:
 
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	virtual bool IsCommandBatchingSupported() override;

--- a/scopehal/SCPISocketCANTransport.cpp
+++ b/scopehal/SCPISocketCANTransport.cpp
@@ -229,7 +229,7 @@ size_t SCPISocketCANTransport::ReadPacket(can_frame* frame, int64_t& sec, int64_
 /**
 	@brief For backward compatibility, doesn't provide timestamps
  */
-size_t SCPISocketCANTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t SCPISocketCANTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	iovec iov;
 	iov.iov_base = buf;

--- a/scopehal/SCPISocketCANTransport.h
+++ b/scopehal/SCPISocketCANTransport.h
@@ -56,7 +56,7 @@ public:
 	virtual void FlushRXBuffer(void) override;
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	size_t ReadPacket(can_frame* frame, int64_t& sec, int64_t& ns);

--- a/scopehal/SCPISocketTransport.h
+++ b/scopehal/SCPISocketTransport.h
@@ -54,7 +54,7 @@ public:
 	virtual void FlushRXBuffer(void) override;
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	virtual bool IsCommandBatchingSupported() override;

--- a/scopehal/SCPITMCTransport.cpp
+++ b/scopehal/SCPITMCTransport.cpp
@@ -167,7 +167,7 @@ void SCPITMCTransport::SendRawData(size_t len, const unsigned char* buf)
 	write(m_handle, (const char *)buf, len);
 }
 
-size_t SCPITMCTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t SCPITMCTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	// Data in the staging buffer is assumed to always be a consequence of a SendCommand request.
 	// Since we fetch all the reply data in one go, once all this data has been fetched, we mark

--- a/scopehal/SCPITMCTransport.h
+++ b/scopehal/SCPITMCTransport.h
@@ -53,7 +53,7 @@ public:
 
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	virtual bool IsCommandBatchingSupported() override;

--- a/scopehal/SCPITransport.h
+++ b/scopehal/SCPITransport.h
@@ -75,7 +75,7 @@ public:
 	virtual void FlushRXBuffer(void);
 	virtual bool SendCommand(const std::string& cmd) =0;
 	virtual std::string ReadReply(bool endOnSemicolon = true) =0;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) =0;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) =0;
 	virtual void SendRawData(size_t len, const unsigned char* buf) =0;
 
 	virtual bool IsCommandBatchingSupported() =0;

--- a/scopehal/SCPITwinLanTransport.cpp
+++ b/scopehal/SCPITwinLanTransport.cpp
@@ -85,7 +85,7 @@ string SCPITwinLanTransport::GetConnectionString()
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Secondary socket I/O
 
-size_t SCPITwinLanTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t SCPITwinLanTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	if(m_secondarysocket.RecvLooped(buf, len))
 		return len;

--- a/scopehal/SCPITwinLanTransport.h
+++ b/scopehal/SCPITwinLanTransport.h
@@ -53,7 +53,7 @@ public:
 	unsigned short GetDataPort()
 	{ return m_dataport; }
 
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	TRANSPORT_INITPROC(SCPITwinLanTransport)

--- a/scopehal/SCPIUARTTransport.cpp
+++ b/scopehal/SCPIUARTTransport.cpp
@@ -121,7 +121,7 @@ void SCPIUARTTransport::SendRawData(size_t len, const unsigned char* buf)
 	m_uart.Write(buf, len);
 }
 
-size_t SCPIUARTTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t SCPIUARTTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	if(!m_uart.Read(buf, len))
 		return 0;

--- a/scopehal/SCPIUARTTransport.h
+++ b/scopehal/SCPIUARTTransport.h
@@ -52,7 +52,7 @@ public:
 
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	virtual bool IsCommandBatchingSupported() override;

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -1544,7 +1544,7 @@ Oscilloscope::TriggerMode SiglentSCPIOscilloscope::PollTrigger()
 	return TRIGGER_MODE_RUN;
 }
 
-int SiglentSCPIOscilloscope::ReadWaveformBlock(uint32_t maxsize, char* data, bool hdSizeWorkaround)
+int SiglentSCPIOscilloscope::ReadWaveformBlock(uint32_t maxsize, char* data, bool hdSizeWorkaround, int slices, size_t channel, int startSlice)
 {
 	//Read and discard data until we see the '#'
 	uint8_t tmp;
@@ -1577,7 +1577,25 @@ int SiglentSCPIOscilloscope::ReadWaveformBlock(uint32_t maxsize, char* data, boo
 	len = min(len, maxsize);
 
 	// Now get the data
-	m_transport->ReadRawData(len, (unsigned char*)data);
+	if(slices > 0)
+	{	// If needed, lices download in shunks to be able to show download progress in progress bar
+		size_t sliceLen = len / slices;
+		size_t bytesRead = 0;
+		for(int i = 0 ; i < slices ; i++)
+		{
+			bytesRead += m_transport->ReadRawData(sliceLen, (unsigned char*)(data+bytesRead));
+			UpdateChannelDownloadState(channel,startSlice+i);
+		}
+		if(bytesRead < len)
+		{	// For the rest (len % slices)
+			m_transport->ReadRawData(len-bytesRead, (unsigned char*)(data+bytesRead));
+		}
+		UpdateChannelDownloadState(channel,startSlice+slices);
+	}
+	else
+	{
+		m_transport->ReadRawData(len, (unsigned char*)data);
+	}
 
 	if(hdSizeWorkaround)
 		return getLength*2;
@@ -1993,7 +2011,7 @@ bool SiglentSCPIOscilloscope::AcquireData()
 					analogWaveformData[i] = new char[WAVEFORM_SIZE];
 					m_transport->SendCommand("C" + to_string(i + 1) + ":WAVEFORM? DAT2");
 					// length of data is current memory depth
-					analogWaveformDataSize[i] = ReadWaveformBlock(WAVEFORM_SIZE, analogWaveformData[i]);
+					analogWaveformDataSize[i] = ReadWaveformBlock(WAVEFORM_SIZE, analogWaveformData[i],false,100,i);
 					// This is the 0x0a0a at the end
 					m_transport->ReadRawData(2, (unsigned char*)tmp);
 				}
@@ -2125,21 +2143,19 @@ bool SiglentSCPIOscilloscope::AcquireData()
 						{	// All data fits one page
 							m_transport->SendCommand(":WAVEFORM:SOURCE C" + to_string(i + 1));
 							m_transport->SendCommand(":WAVEFORM:DATA?");
-							analogWaveformDataSize[i] = ReadWaveformBlock(acqBytes, analogWaveformData[i], hdWorkaround);
+							analogWaveformDataSize[i] = ReadWaveformBlock(acqBytes, analogWaveformData[i], hdWorkaround,100,i);
 							// This is the 0x0a0a at the end
 							m_transport->ReadRawData(2, (unsigned char*)tmp);
 						}
 						else
 						{	// We need pagination
 							m_transport->SendCommand(":WAVEFORM:SOURCE C" + to_string(i + 1));
-							int percent = 100/pages;
-							int percentage = 0;
+							int pagePercent = 100/pages;
 							for(uint64_t page = 0; page < pages; page++)
 							{
-								UpdateChannelDownloadState(i,page*percent);
 								m_transport->SendCommand(":WAVEFORM:START "+ to_string(page*pageSize));
 								m_transport->SendCommand(":WAVEFORM:DATA?");
-								analogWaveformDataSize[i] += ReadWaveformBlock(acqBytes-analogWaveformDataSize[i], analogWaveformData[i]+analogWaveformDataSize[i], hdWorkaround);
+								analogWaveformDataSize[i] += ReadWaveformBlock(acqBytes-analogWaveformDataSize[i], analogWaveformData[i]+analogWaveformDataSize[i], hdWorkaround,pagePercent,i,page*pagePercent);
 								// This is the 0x0a0a at the end
 								m_transport->ReadRawData(2, (unsigned char*)tmp);
 							}
@@ -2170,25 +2186,23 @@ bool SiglentSCPIOscilloscope::AcquireData()
 							if(!paginated)
 							{	// All data fits one page
 								m_transport->SendCommand(":WAVEFORM:SOURCE D" + to_string(i) + ";:WAVEFORM:DATA?");
-								digitalWaveformDataSize[i] = ReadWaveformBlock(acqDigitalBytes, digitalWaveformDataBytes[i], false);
+								digitalWaveformDataSize[i] = ReadWaveformBlock(acqDigitalBytes, digitalWaveformDataBytes[i], false, 100, i+m_analogChannelCount);
 								// This is the 0x0a0a at the end
 								m_transport->ReadRawData(2, (unsigned char*)tmp);
 							}
 							else
 							{	// We need pagination
 								m_transport->SendCommand(":WAVEFORM:SOURCE D" + to_string(i));
-								int percent = 100/pages;
-								int percentage = 0;
+								int pagePercent = 100/pages;
 								for(uint64_t page = 0; page < pages; page++)
 								{
-									UpdateChannelDownloadState(i,page*percent);
 									// LogDebug("Requesting %lld bytes from byte count to %d.\n",acqDigitalBytes-digitalWaveformDataSize[i],digitalWaveformDataSize[i]);
 									m_transport->SendCommand(":WAVEFORM:START "+ to_string(page*pageSize) + ";:WAVEFORM:DATA?");
-									digitalWaveformDataSize[i] += ReadWaveformBlock(acqDigitalBytes-digitalWaveformDataSize[i], digitalWaveformDataBytes[i]+digitalWaveformDataSize[i], false);
+									digitalWaveformDataSize[i] += ReadWaveformBlock(acqDigitalBytes-digitalWaveformDataSize[i], digitalWaveformDataBytes[i]+digitalWaveformDataSize[i], false, pagePercent, i+m_analogChannelCount, page*pagePercent);
 									// This is the 0x0a0a at the end
 									m_transport->ReadRawData(2, (unsigned char*)tmp);
 								}
-								UpdateChannelDownloadState(i,100);
+								UpdateChannelDownloadState(i+m_analogChannelCount,100);
 							}
 						}
 					}

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -2060,6 +2060,9 @@ bool SiglentSCPIOscilloscope::AcquireData()
 				for(size_t j = 0; j < num_sequences; j++)
 					pending_waveforms[i].push_back(waveforms[i][j]);
 			}
+
+			for(unsigned int i = 0; i < m_analogChannelCount; i++)
+				ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
 			break;
 
 		// --------------------------------------------------
@@ -2101,7 +2104,7 @@ bool SiglentSCPIOscilloscope::AcquireData()
 			if(pdesc)
 			{	// Notify about download operation start
 				ChannelsDownloadStarted();
-				
+
 				// Handle the case when only digital channel is activated
 				// Figure out when the first trigger happened.
 				//Read the timestamps if we're doing segmented capture
@@ -2264,6 +2267,11 @@ bool SiglentSCPIOscilloscope::AcquireData()
 					for(size_t j = 0; j < num_sequences; j++)
 						pending_waveforms[i+m_analogChannelCount].push_back(digitalWaveforms[i][j]);
 				}
+
+				for(unsigned int i = 0; i < m_analogChannelCount; i++)
+					ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
+				for(unsigned int i = 0; i < m_digitalChannelCount; i++)
+					ChannelsDownloadStatusUpdate(i+m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
 			}
 
 			break;

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -2003,6 +2003,10 @@ bool SiglentSCPIOscilloscope::AcquireData()
 				analogEnabled[i] = IsChannelEnabled(i);
 				anyAnalogEnabled |= analogEnabled[i];
 			}
+
+			// Notify about download operation start
+			ChannelsDownloadStarted();
+
 			start = GetTime();
 			for(unsigned int i = 0; i < m_analogChannelCount; i++)
 			{

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -2179,7 +2179,7 @@ bool SiglentSCPIOscilloscope::AcquireData()
 							if(!paginated)
 							{	// All data fits one page
 								m_transport->SendCommand(":WAVEFORM:SOURCE D" + to_string(i) + ";:WAVEFORM:DATA?");
-								digitalWaveformDataSize[i] = ReadWaveformBlock(acqDigitalBytes, digitalWaveformDataBytes[i], false, [i, this] (float progress) { ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, progress); });
+								digitalWaveformDataSize[i] = ReadWaveformBlock(acqDigitalBytes, digitalWaveformDataBytes[i], false, [i, this] (float progress) { ChannelsDownloadStatusUpdate(i + m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, progress); });
 								// This is the 0x0a0a at the end
 								m_transport->ReadRawData(2, (unsigned char*)tmp);
 							}
@@ -2192,7 +2192,7 @@ bool SiglentSCPIOscilloscope::AcquireData()
 									m_transport->SendCommand(":WAVEFORM:START "+ to_string(page*pageSize) + ";:WAVEFORM:DATA?");
 									auto progress = [i, this, page, pages] (float progress) {
 										float linear_progress = ((float)page + progress) / (float)pages; // the last page will go slightly faster, but oh well
-										ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, linear_progress);
+										ChannelsDownloadStatusUpdate(i + m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, linear_progress);
 									};
 									digitalWaveformDataSize[i] += ReadWaveformBlock(acqDigitalBytes-digitalWaveformDataSize[i], digitalWaveformDataBytes[i]+digitalWaveformDataSize[i], false, progress);
 									// This is the 0x0a0a at the end

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -282,7 +282,7 @@ protected:
 
 	std::string GetPossiblyEmptyString(const std::string& property);
 
-	int ReadWaveformBlock(uint32_t maxsize, char* data, bool hdSizeWorkaround = false, int slices = -1, size_t channel = 0, int startSlice = 0);
+	int ReadWaveformBlock(uint32_t maxsize, char* data, bool hdSizeWorkaround = false, std::function<void(float)> progress = nullptr);
 	bool ReadWavedescs(
 		char wavedescs[MAX_ANALOG][WAVEDESC_SIZE], bool* analogEnabled, bool* digitalEnabled, bool& anyAnalogEnabled, bool& anyDigitalEnabled);
 

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -347,6 +347,7 @@ protected:
 	//Cached configuration
 	std::map<size_t, float> m_channelVoltageRanges;
 	std::map<size_t, float> m_channelOffsets;
+	std::map<size_t, float> m_channelDigitalThresholds;
 	std::map<int, bool> m_channelsEnabled;
 	bool m_sampleRateValid;
 	int64_t m_sampleRate;

--- a/scopehal/SiglentSCPIOscilloscope.h
+++ b/scopehal/SiglentSCPIOscilloscope.h
@@ -282,14 +282,7 @@ protected:
 
 	std::string GetPossiblyEmptyString(const std::string& property);
 
-	//  bool ReadWaveformBlock(std::string& data);
-	int ReadWaveformBlock(uint32_t maxsize, char* data, bool hdSizeWorkaround = false);
-	//  	bool ReadWavedescs(
-	//		std::vector<std::string>& wavedescs,
-	//		bool* analogEnabled,
-	//		bool* digitalEnabled,
-	//		bool& anyAnalogEnabled,
-	//		bool& anyDigitalEnabled);
+	int ReadWaveformBlock(uint32_t maxsize, char* data, bool hdSizeWorkaround = false, int slices = -1, size_t channel = 0, int startSlice = 0);
 	bool ReadWavedescs(
 		char wavedescs[MAX_ANALOG][WAVEDESC_SIZE], bool* analogEnabled, bool* digitalEnabled, bool& anyAnalogEnabled, bool& anyDigitalEnabled);
 

--- a/scopehal/TektronixOscilloscope.h
+++ b/scopehal/TektronixOscilloscope.h
@@ -300,6 +300,9 @@ protected:
 	///@brief Cached map of <channel ID, full scale range>
 	std::map<size_t, float> m_channelVoltageRanges;
 
+	///@brief Cached map of <channel ID, digital threshold>
+	std::map<size_t, float> m_channelDigitalThresholds;
+
 	///@brief Cached map of <channel ID, coupling>
 	std::map<size_t, OscilloscopeChannel::CouplingType> m_channelCouplings;
 
@@ -357,6 +360,9 @@ protected:
 
 	///@brief Starting index for digital channels
 	size_t m_digitalChannelBase;
+
+	///@brief Nuber of digital channels
+	size_t m_digitalChannelCount;
 
 	///@brief Starting index for spectrum channels
 	size_t m_spectrumChannelBase;

--- a/scopehal/TestWaveformSource.cpp
+++ b/scopehal/TestWaveformSource.cpp
@@ -127,6 +127,7 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewave(
 	float period,
 	int64_t sampleperiod,
 	size_t depth,
+	std::function<void(int)> downloadCallback,
 	float noise_stdev)
 {
 	auto ret = new UniformAnalogWaveform("NoisySine");
@@ -141,9 +142,20 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewave(
 	//sin is +/- 1, so need to divide amplitude by 2 to get scaling factor
 	float scale = amplitude / 2;
 
+	size_t percent = depth / 100;
+	size_t percentage = 0;
+	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
+	{
+		if(i/percent != percentage)
+		{
+			percentage = i/percent;
+			downloadCallback((int)percentage);
+		}
 		ret->m_samples[i] = scale * sinf(i*radians_per_sample + startphase) + noise(m_rng);
+	}
 
+	downloadCallback(100);
 	return ret;
 }
 
@@ -167,6 +179,7 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewaveSum(
 	float period2,
 	int64_t sampleperiod,
 	size_t depth,
+	std::function<void(int)> downloadCallback,
 	float noise_stdev)
 {
 	auto ret = new UniformAnalogWaveform("NoisySineSum");
@@ -182,13 +195,22 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewaveSum(
 	//Divide by 2 again to avoid clipping the sum of them
 	float scale = amplitude / 4;
 
+	size_t percent = depth / 100;
+	size_t percentage = 0;
+	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
+		if(i/percent != percentage)
+		{
+			percentage = i/percent;
+			downloadCallback((int)percentage);
+		}
 		ret->m_samples[i] = scale *
 			(sinf(i*radians_per_sample1 + startphase1) + sinf(i*radians_per_sample2 + startphase2))
 			+ noise(m_rng);
 	}
 
+	downloadCallback(100);
 	return ret;
 }
 
@@ -211,6 +233,7 @@ WaveformBase* TestWaveformSource::GeneratePRBS31(
 	float period,
 	int64_t sampleperiod,
 	size_t depth,
+	std::function<void(int)> downloadCallback,
 	bool lpf,
 	float noise_stdev
 	)
@@ -224,8 +247,16 @@ WaveformBase* TestWaveformSource::GeneratePRBS31(
 	float scale = amplitude / 2;
 	float phase_to_next_edge = period;
 	bool value = false;
+	size_t percent = depth / 100;
+	size_t percentage = 0;
+	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
+		if(i/percent != percentage)
+		{
+			percentage = i/percent;
+			downloadCallback((int)percentage);
+		}
 		//Increment phase accumulator
 		float last_phase = phase_to_next_edge;
 		phase_to_next_edge -= sampleperiod;
@@ -258,6 +289,7 @@ WaveformBase* TestWaveformSource::GeneratePRBS31(
 	}
 
 	DegradeSerialData(ret, sampleperiod, depth, lpf, noise_stdev, cmdBuf, queue);
+	downloadCallback(100);
 
 	return ret;
 }
@@ -281,6 +313,7 @@ WaveformBase* TestWaveformSource::Generate8b10b(
 	float period,
 	int64_t sampleperiod,
 	size_t depth,
+	std::function<void(int)> downloadCallback,
 	bool lpf,
 	float noise_stdev)
 {
@@ -300,8 +333,16 @@ WaveformBase* TestWaveformSource::Generate8b10b(
 	float phase_to_next_edge = period;
 	bool value = false;
 	int nbit = 0;
+	size_t percent = depth / 100;
+	size_t percentage = 0;
+	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
+		if(i/percent != percentage)
+		{
+			percentage = i/percent;
+			downloadCallback((int)percentage);
+		}
 		//Increment phase accumulator
 		float last_phase = phase_to_next_edge;
 		phase_to_next_edge -= sampleperiod;
@@ -334,6 +375,7 @@ WaveformBase* TestWaveformSource::Generate8b10b(
 	}
 
 	DegradeSerialData(ret, sampleperiod, depth, lpf, noise_stdev, cmdBuf, queue);
+	downloadCallback(100);
 
 	return ret;
 }

--- a/scopehal/TestWaveformSource.cpp
+++ b/scopehal/TestWaveformSource.cpp
@@ -127,7 +127,7 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewave(
 	float period,
 	int64_t sampleperiod,
 	size_t depth,
-	std::function<void(int)> downloadCallback,
+	std::function<void(float)> downloadCallback,
 	float noise_stdev)
 {
 	auto ret = new UniformAnalogWaveform("NoisySine");
@@ -142,20 +142,15 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewave(
 	//sin is +/- 1, so need to divide amplitude by 2 to get scaling factor
 	float scale = amplitude / 2;
 
-	size_t percent = depth / 100;
-	size_t percentage = 0;
-	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
-		if(i/percent != percentage)
-		{
-			percentage = i/percent;
-			downloadCallback((int)percentage);
-		}
 		ret->m_samples[i] = scale * sinf(i*radians_per_sample + startphase) + noise(m_rng);
+		if (i % 1024 == 0)
+		{
+			downloadCallback((float)i / (float)depth);
+		}
 	}
 
-	downloadCallback(100);
 	return ret;
 }
 
@@ -179,7 +174,7 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewaveSum(
 	float period2,
 	int64_t sampleperiod,
 	size_t depth,
-	std::function<void(int)> downloadCallback,
+	std::function<void(float)> downloadCallback,
 	float noise_stdev)
 {
 	auto ret = new UniformAnalogWaveform("NoisySineSum");
@@ -195,22 +190,18 @@ WaveformBase* TestWaveformSource::GenerateNoisySinewaveSum(
 	//Divide by 2 again to avoid clipping the sum of them
 	float scale = amplitude / 4;
 
-	size_t percent = depth / 100;
-	size_t percentage = 0;
-	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
-		if(i/percent != percentage)
-		{
-			percentage = i/percent;
-			downloadCallback((int)percentage);
-		}
 		ret->m_samples[i] = scale *
 			(sinf(i*radians_per_sample1 + startphase1) + sinf(i*radians_per_sample2 + startphase2))
 			+ noise(m_rng);
+		if (i % 1024 == 0)
+		{
+			downloadCallback((float)i / (float)depth);
+		}
+
 	}
 
-	downloadCallback(100);
 	return ret;
 }
 
@@ -233,7 +224,7 @@ WaveformBase* TestWaveformSource::GeneratePRBS31(
 	float period,
 	int64_t sampleperiod,
 	size_t depth,
-	std::function<void(int)> downloadCallback,
+	std::function<void(float)> downloadCallback,
 	bool lpf,
 	float noise_stdev
 	)
@@ -247,16 +238,8 @@ WaveformBase* TestWaveformSource::GeneratePRBS31(
 	float scale = amplitude / 2;
 	float phase_to_next_edge = period;
 	bool value = false;
-	size_t percent = depth / 100;
-	size_t percentage = 0;
-	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
-		if(i/percent != percentage)
-		{
-			percentage = i/percent;
-			downloadCallback((int)percentage);
-		}
 		//Increment phase accumulator
 		float last_phase = phase_to_next_edge;
 		phase_to_next_edge -= sampleperiod;
@@ -286,10 +269,14 @@ WaveformBase* TestWaveformSource::GeneratePRBS31(
 
 			ret->m_samples[i] = last_voltage + delta*frac;
 		}
+
+		if (i % 1024 == 0)
+		{
+			downloadCallback((float)i / (float)depth);
+		}
 	}
 
 	DegradeSerialData(ret, sampleperiod, depth, lpf, noise_stdev, cmdBuf, queue);
-	downloadCallback(100);
 
 	return ret;
 }
@@ -313,7 +300,7 @@ WaveformBase* TestWaveformSource::Generate8b10b(
 	float period,
 	int64_t sampleperiod,
 	size_t depth,
-	std::function<void(int)> downloadCallback,
+	std::function<void(float)> downloadCallback,
 	bool lpf,
 	float noise_stdev)
 {
@@ -333,16 +320,8 @@ WaveformBase* TestWaveformSource::Generate8b10b(
 	float phase_to_next_edge = period;
 	bool value = false;
 	int nbit = 0;
-	size_t percent = depth / 100;
-	size_t percentage = 0;
-	downloadCallback(0);
 	for(size_t i=0; i<depth; i++)
 	{
-		if(i/percent != percentage)
-		{
-			percentage = i/percent;
-			downloadCallback((int)percentage);
-		}
 		//Increment phase accumulator
 		float last_phase = phase_to_next_edge;
 		phase_to_next_edge -= sampleperiod;
@@ -372,10 +351,14 @@ WaveformBase* TestWaveformSource::Generate8b10b(
 
 			ret->m_samples[i] = last_voltage + delta*frac;
 		}
+
+		if (i % 1024 == 0)
+		{
+			downloadCallback((float)i / (float)depth);
+		}
 	}
 
 	DegradeSerialData(ret, sampleperiod, depth, lpf, noise_stdev, cmdBuf, queue);
-	downloadCallback(100);
 
 	return ret;
 }

--- a/scopehal/TestWaveformSource.h
+++ b/scopehal/TestWaveformSource.h
@@ -62,7 +62,7 @@ public:
 		float period,
 		int64_t sampleperiod,
 		size_t depth,
-		std::function<void(int)> downloadCallback,
+		std::function<void(float)> downloadCallback,
 		float noise_stdev = 0.01);
 
 	WaveformBase* GenerateNoisySinewaveSum(
@@ -73,7 +73,7 @@ public:
 		float period2,
 		int64_t sampleperiod,
 		size_t depth,
-		std::function<void(int)> downloadCallback,
+		std::function<void(float)> downloadCallback,
 		float noise_stdev = 0.01);
 
 	WaveformBase* GeneratePRBS31(
@@ -83,7 +83,7 @@ public:
 		float period,
 		int64_t sampleperiod,
 		size_t depth,
-		std::function<void(int)> downloadCallback,
+		std::function<void(float)> downloadCallback,
 		bool lpf = true,
 		float noise_stdev = 0.01);
 
@@ -94,7 +94,7 @@ public:
 		float period,
 		int64_t sampleperiod,
 		size_t depth,
-		std::function<void(int)> downloadCallback,
+		std::function<void(float)> downloadCallback,
 		bool lpf = true,
 		float noise_stdev = 0.01);
 

--- a/scopehal/TestWaveformSource.h
+++ b/scopehal/TestWaveformSource.h
@@ -62,6 +62,7 @@ public:
 		float period,
 		int64_t sampleperiod,
 		size_t depth,
+		std::function<void(int)> downloadCallback,
 		float noise_stdev = 0.01);
 
 	WaveformBase* GenerateNoisySinewaveSum(
@@ -72,6 +73,7 @@ public:
 		float period2,
 		int64_t sampleperiod,
 		size_t depth,
+		std::function<void(int)> downloadCallback,
 		float noise_stdev = 0.01);
 
 	WaveformBase* GeneratePRBS31(
@@ -81,6 +83,7 @@ public:
 		float period,
 		int64_t sampleperiod,
 		size_t depth,
+		std::function<void(int)> downloadCallback,
 		bool lpf = true,
 		float noise_stdev = 0.01);
 
@@ -91,6 +94,7 @@ public:
 		float period,
 		int64_t sampleperiod,
 		size_t depth,
+		std::function<void(int)> downloadCallback,
 		bool lpf = true,
 		float noise_stdev = 0.01);
 

--- a/scopehal/VICPSocketTransport.cpp
+++ b/scopehal/VICPSocketTransport.cpp
@@ -223,7 +223,7 @@ void VICPSocketTransport::SendRawData(size_t len, const unsigned char* buf)
 	m_socket.SendLooped(buf, len);
 }
 
-size_t VICPSocketTransport::ReadRawData(size_t len, unsigned char* buf)
+size_t VICPSocketTransport::ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> /*progress*/)
 {
 	if(!m_socket.RecvLooped(buf, len))
 		return 0;

--- a/scopehal/VICPSocketTransport.h
+++ b/scopehal/VICPSocketTransport.h
@@ -63,7 +63,7 @@ public:
 
 	virtual bool SendCommand(const std::string& cmd) override;
 	virtual std::string ReadReply(bool endOnSemicolon = true) override;
-	virtual size_t ReadRawData(size_t len, unsigned char* buf) override;
+	virtual size_t ReadRawData(size_t len, unsigned char* buf, std::function<void(float)> progress = nullptr) override;
 	virtual void SendRawData(size_t len, const unsigned char* buf) override;
 
 	virtual bool IsCommandBatchingSupported() override;


### PR DESCRIPTION
Hi Andrew,
Here is the PR for the GetDownloadState() API.
As discussed it is available on OscilloscopeChannel and implemented in Oscilloscope base class.
Driver classes should call:
1/ ChannlesDownloadStarted() method at the start of a download operation
2/ UpdateChannelDownloadState() each time the progress bar should be updated (i.e. each time one more percent of the waveform has been downloaded)

The default implementation tries and guess whether the progress bar should be displayed or not based on the estimated download speed. Once calculated, this value will stay valid until the sample-depth or the number of enabled channels changes.

Drivers may use the SetShowChannelsDownloadProgress() method to force showing progress bar or not based on their own implementation.