### PR TITLE
Fixes for download progress display.

### DIFF
--- a/scopehal/DemoOscilloscope.cpp
+++ b/scopehal/DemoOscilloscope.cpp
@@ -201,8 +201,6 @@ void DemoOscilloscope::Stop()
 {
 	m_triggerArmed = false;
 	m_triggerOneShot = false;
-	// Tell the download monitor that no more waveform are going to be downloaded
-	AcquisitionStopped();
 }
 
 void DemoOscilloscope::ForceTrigger()
@@ -603,6 +601,9 @@ bool DemoOscilloscope::AcquireData()
 
 	if(m_triggerOneShot)
 		m_triggerArmed = false;
+
+	// Tell the download monitor that waveform download has finished
+	ChannelsDownloadFinished();
 
 	return true;
 }

--- a/scopehal/DemoOscilloscope.cpp
+++ b/scopehal/DemoOscilloscope.cpp
@@ -577,7 +577,6 @@ bool DemoOscilloscope::AcquireData()
 	for(int i=0; i<4; i++)
 	{
 		s[GetOscilloscopeChannel(i)] = waveforms[i];
-		this->ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 0.0);
 	}
 
 	//Timestamp the waveform(s)

--- a/scopehal/DemoOscilloscope.cpp
+++ b/scopehal/DemoOscilloscope.cpp
@@ -201,6 +201,8 @@ void DemoOscilloscope::Stop()
 {
 	m_triggerArmed = false;
 	m_triggerOneShot = false;
+	// Tell the download monitor that no more waveform are going to be downloaded
+	AcquisitionStopped();
 }
 
 void DemoOscilloscope::ForceTrigger()

--- a/scopehal/Oscilloscope.cpp
+++ b/scopehal/Oscilloscope.cpp
@@ -880,7 +880,7 @@ void Oscilloscope::ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::Do
 	chan->m_downloadProgress = progress;
 }
 
-void Oscilloscope::AcquisitionStopped()
+void Oscilloscope::ChannelsDownloadFinished()
 {
 	for (size_t i = 0; i < m_channels.size(); i++)
 	{

--- a/scopehal/Oscilloscope.cpp
+++ b/scopehal/Oscilloscope.cpp
@@ -880,6 +880,17 @@ void Oscilloscope::ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::Do
 	chan->m_downloadProgress = progress;
 }
 
+void Oscilloscope::AcquisitionStopped()
+{
+	for (size_t i = 0; i < m_channels.size(); i++)
+	{
+		auto chan = GetOscilloscopeChannel(i);
+		if (chan == nullptr)
+			continue;
+
+		chan->m_downloadState = InstrumentChannel::DownloadState::DOWNLOAD_NONE;
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Trigger configuration

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -397,8 +397,8 @@ protected:
 		or if all channels are downloaded at the same speed.
 
 		@param ch 			Zero-based index of channel
-		@param state		the new InstrumentChannel::DownloadState for this channel
-		@param progress		A one based float value representing the download progress
+		@param state		The new InstrumentChannel::DownloadState for this channel
+		@param progress		A float value ranging from 0 to 1 to represent the download progress
 	 */
 	void ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::DownloadState state, float progress);
 

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -389,7 +389,17 @@ protected:
 	/// @brief Helper method called by drivers to reset all channels to "waiting to download" state.
 	void ChannelsDownloadStarted();
 
-	/// @brief Helper method called by drivers to set one channel's download status.
+	/**
+	 	@brief Helper method called by drivers to set one channel's download status and update its download progress.
+		Be aware that there is a measurement on ngscopeclient UI of the time spent between the download start and 
+		the progress of the last enabled channel. This measurement is used to decide whether to display a progress bar or not.
+		This download speed evaluation method only works if enabled channels are download sequencially in increasing numeric order
+		or if all channels are downloaded at the same speed.
+
+		@param ch 			Zero-based index of channel
+		@param state		the new InstrumentChannel::DownloadState for this channel
+		@param progress		A one based float value representing the download progress
+	 */
 	void ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::DownloadState state, float progress);
 
 	/// @brief Helper method called by drivers when waveform download is finished to reset all channels to "no download" state.

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -392,6 +392,9 @@ protected:
 	/// @brief Helper method called by drivers to set one channel's download status.
 	void ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::DownloadState state, float progress);
 
+	/// @brief Helper method called by drivers when acquisition is stopped to reset all channels to "no download" state.
+	void AcquisitionStopped();
+
 public:
 	//Triggering
 	enum TriggerMode

--- a/scopehal/Oscilloscope.h
+++ b/scopehal/Oscilloscope.h
@@ -392,8 +392,8 @@ protected:
 	/// @brief Helper method called by drivers to set one channel's download status.
 	void ChannelsDownloadStatusUpdate(size_t ch, InstrumentChannel::DownloadState state, float progress);
 
-	/// @brief Helper method called by drivers when acquisition is stopped to reset all channels to "no download" state.
-	void AcquisitionStopped();
+	/// @brief Helper method called by drivers when waveform download is finished to reset all channels to "no download" state.
+	void ChannelsDownloadFinished();
 
 public:
 	//Triggering

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1103,6 +1103,8 @@ void RigolOscilloscope::Stop()
 	m_liveMode = false;
 	m_triggerArmed = false;
 	m_triggerOneShot = true;
+	// Tell the download monitor that no more waveform are going to be downloaded
+	AcquisitionStopped();
 }
 
 void RigolOscilloscope::ForceTrigger()

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1001,6 +1001,11 @@ bool RigolOscilloscope::AcquireData()
 	//Clean up
 	delete[] temp_buf;
 
+	// Tell the download monitor that waveform download has finished
+	ChannelsDownloadFinished();
+
+	//TODO: support digital channels
+
 	//Re-arm the trigger if not in one-shot mode
 	if(!m_triggerOneShot)
 	{
@@ -1103,8 +1108,6 @@ void RigolOscilloscope::Stop()
 	m_liveMode = false;
 	m_triggerArmed = false;
 	m_triggerOneShot = true;
-	// Tell the download monitor that no more waveform are going to be downloaded
-	AcquisitionStopped();
 }
 
 void RigolOscilloscope::ForceTrigger()

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1001,12 +1001,6 @@ bool RigolOscilloscope::AcquireData()
 	//Clean up
 	delete[] temp_buf;
 
-	// Everything is done, and nothing else has anything in its buffer anymore.
-	for(size_t i = 0; i < m_analogChannelCount; i++)
-		ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
-
-	//TODO: support digital channels
-
 	//Re-arm the trigger if not in one-shot mode
 	if(!m_triggerOneShot)
 	{

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -2060,6 +2060,9 @@ bool SiglentSCPIOscilloscope::AcquireData()
 				for(size_t j = 0; j < num_sequences; j++)
 					pending_waveforms[i].push_back(waveforms[i][j]);
 			}
+
+			// Tell the download monitor that waveform download has finished
+			ChannelsDownloadFinished();
 			break;
 
 		// --------------------------------------------------
@@ -2266,6 +2269,9 @@ bool SiglentSCPIOscilloscope::AcquireData()
 					for(size_t j = 0; j < num_sequences; j++)
 						pending_waveforms[i+m_analogChannelCount].push_back(digitalWaveforms[i][j]);
 				}
+
+				// Tell the download monitor that waveform download has finished
+				ChannelsDownloadFinished();
 			}
 
 			break;

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -2153,8 +2153,8 @@ bool SiglentSCPIOscilloscope::AcquireData()
 								m_transport->ReadRawData(2, (unsigned char*)tmp);
 							}
 						}
+						ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_FINISHED, 1.0);
 					}
-					ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_FINISHED, 1.0);
 				}
 				if(anyDigitalEnabled)
 				{
@@ -2178,7 +2178,8 @@ bool SiglentSCPIOscilloscope::AcquireData()
 							digitalWaveformDataBytes[i] = new char[acqDigitalBytes];
 							if(!paginated)
 							{	// All data fits one page
-								m_transport->SendCommand(":WAVEFORM:SOURCE D" + to_string(i) + ";:WAVEFORM:DATA?");
+								m_transport->SendCommand(":WAVEFORM:SOURCE D" + to_string(i));
+								m_transport->SendCommand(":WAVEFORM:DATA?");
 								digitalWaveformDataSize[i] = ReadWaveformBlock(acqDigitalBytes, digitalWaveformDataBytes[i], false, [i, this] (float progress) { ChannelsDownloadStatusUpdate(i + m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, progress); });
 								// This is the 0x0a0a at the end
 								m_transport->ReadRawData(2, (unsigned char*)tmp);
@@ -2189,7 +2190,8 @@ bool SiglentSCPIOscilloscope::AcquireData()
 								for(uint64_t page = 0; page < pages; page++)
 								{
 									// LogDebug("Requesting %lld bytes from byte count to %d.\n",acqDigitalBytes-digitalWaveformDataSize[i],digitalWaveformDataSize[i]);
-									m_transport->SendCommand(":WAVEFORM:START "+ to_string(page*pageSize) + ";:WAVEFORM:DATA?");
+									m_transport->SendCommand(":WAVEFORM:START "+ to_string(page*pageSize));
+									m_transport->SendCommand(":WAVEFORM:DATA?");
 									auto progress = [i, this, page, pages] (float fprogress) {
 										float linear_progress = ((float)page + fprogress) / (float)pages; // the last page will go slightly faster, but oh well
 										ChannelsDownloadStatusUpdate(i + m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, linear_progress);
@@ -2199,8 +2201,8 @@ bool SiglentSCPIOscilloscope::AcquireData()
 									m_transport->ReadRawData(2, (unsigned char*)tmp);
 								}
 							}
+							ChannelsDownloadStatusUpdate(i + m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_FINISHED, 1.0);
 						}
-						ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_FINISHED, 1.0);
 					}
 				}
 

--- a/scopehal/SiglentSCPIOscilloscope.cpp
+++ b/scopehal/SiglentSCPIOscilloscope.cpp
@@ -2060,9 +2060,6 @@ bool SiglentSCPIOscilloscope::AcquireData()
 				for(size_t j = 0; j < num_sequences; j++)
 					pending_waveforms[i].push_back(waveforms[i][j]);
 			}
-
-			for(unsigned int i = 0; i < m_analogChannelCount; i++)
-				ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
 			break;
 
 		// --------------------------------------------------
@@ -2269,11 +2266,6 @@ bool SiglentSCPIOscilloscope::AcquireData()
 					for(size_t j = 0; j < num_sequences; j++)
 						pending_waveforms[i+m_analogChannelCount].push_back(digitalWaveforms[i][j]);
 				}
-
-				for(unsigned int i = 0; i < m_analogChannelCount; i++)
-					ChannelsDownloadStatusUpdate(i, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
-				for(unsigned int i = 0; i < m_digitalChannelCount; i++)
-					ChannelsDownloadStatusUpdate(i+m_analogChannelCount, InstrumentChannel::DownloadState::DOWNLOAD_NONE, 1.0);
 			}
 
 			break;


### PR DESCRIPTION
This fixes a bug in Siglent driver for progress of digital channels + removes calls to ChannelsDownloadStatusUpdate() with DOWNLOAD_NONE to prevent flickering.