### PR TITLE
ModbusInstrument refactoring to use BinaryDriver helper methods

### DIFF
--- a/scopehal/ModbusInstrument.cpp
+++ b/scopehal/ModbusInstrument.cpp
@@ -51,23 +51,10 @@ ModbusInstrument::~ModbusInstrument()
 
 }
 
-void ModbusInstrument::PushUint16(std::vector<uint8_t>* data, uint16_t value)
-{
-	data->push_back(reinterpret_cast<uint8_t *>(&value)[1]);
-	data->push_back(reinterpret_cast<uint8_t *>(&value)[0]);
-}
-
-uint16_t ModbusInstrument::ReadUint16(std::vector<uint8_t>* data, uint8_t index)
-{
-	if(!data || data->size() <= ((size_t)(index+1)))
-		return 0;
-	return (static_cast<uint16_t>((*data)[index+1]) + (static_cast<uint16_t>((*data)[index]) << 8));
-}
-
 void ModbusInstrument::Converse(ModbusFunction function, std::vector<uint8_t>* data)
 {
 	lock_guard<recursive_mutex> lock(m_modbusMutex);
-	SendCommand (function,data);
+	SendCommand (function,(*data));
 	ReadResponse(function,data);
 }
 
@@ -75,9 +62,9 @@ uint16_t ModbusInstrument::ReadRegister(uint16_t address)
 {
 	std::vector<uint8_t> data;
 	// Adress to read
-	PushUint16(&data,address);
+	PushUint16(&data,address,false);
 	// Number of registers to read (1)
-	PushUint16(&data,0x0001);
+	PushUint16(&data,0x0001,false);
 	Converse(ReadAnalogOutputHoldingRegisters,&data);
 	// Response data should be the 2 bytes of the requested register
 	if(data.size() < 2)
@@ -85,16 +72,16 @@ uint16_t ModbusInstrument::ReadRegister(uint16_t address)
 		LogError("Invalid response length: %zu, expected 2.\n", data.size());
 		return 0;
 	}
-	return ReadUint16(&data,0);
+	return ReadUint16(data,0,false);
 }
 
 uint16_t ModbusInstrument::WriteRegister(uint16_t address, uint16_t value)
 {
 	std::vector<uint8_t> data;
 	// Adress to write
-	PushUint16(&data,address);
+	PushUint16(&data,address,false);
 	// Data to write
-	PushUint16(&data,value);
+	PushUint16(&data,value,false);
 	Converse(WriteSingleAnalogOutputRegister,&data);
 	// Response data should be the 4 bytes (2 adress bytes and 2 bytes for the requested register)
 	if(data.size() < 4)
@@ -102,7 +89,7 @@ uint16_t ModbusInstrument::WriteRegister(uint16_t address, uint16_t value)
 		LogError("Invalid response length: %zu, expected 4.\n",data.size());
 		return 0;
 	}
-	return ReadUint16(&data,2);
+	return ReadUint16(data,2,false);
 }
 
 uint8_t ModbusInstrument::ReadRegisters(uint16_t address, std::vector<uint16_t>* result, uint8_t count)
@@ -112,9 +99,9 @@ uint8_t ModbusInstrument::ReadRegisters(uint16_t address, std::vector<uint16_t>*
 	uint16_t byteCount = count*2;
 	std::vector<uint8_t> data;
 	// Adress to read
-	PushUint16(&data,address);
+	PushUint16(&data,address,false);
 	// Number of registers to read (1)
-	PushUint16(&data,count);
+	PushUint16(&data,count,false);
 	Converse(ReadAnalogOutputHoldingRegisters,&data);
 	// Response data should be the 2 bytes of the requested register
 	if(data.size() != byteCount)
@@ -125,69 +112,21 @@ uint8_t ModbusInstrument::ReadRegisters(uint16_t address, std::vector<uint16_t>*
 	result->reserve(count);
 	for(int i = 0 ; i < count ; i++)
 	{
-		result->push_back(ReadUint16(&data,2*i));
+		result->push_back(ReadUint16(data,2*i,false));
 	}
 	return count;
 }
 
-
-uint16_t ModbusInstrument::CalculateCRC(const uint8_t *buff, size_t len)
-{
-	static const uint16_t wCRCTable[] =
-	{
-		0X0000, 0XC0C1, 0XC181, 0X0140, 0XC301, 0X03C0, 0X0280, 0XC241, 0XC601,
-		0X06C0, 0X0780, 0XC741, 0X0500, 0XC5C1, 0XC481, 0X0440, 0XCC01, 0X0CC0,
-		0X0D80, 0XCD41, 0X0F00, 0XCFC1, 0XCE81, 0X0E40, 0X0A00, 0XCAC1, 0XCB81,
-		0X0B40, 0XC901, 0X09C0, 0X0880, 0XC841, 0XD801, 0X18C0, 0X1980, 0XD941,
-		0X1B00, 0XDBC1, 0XDA81, 0X1A40, 0X1E00, 0XDEC1, 0XDF81, 0X1F40, 0XDD01,
-		0X1DC0, 0X1C80, 0XDC41, 0X1400, 0XD4C1, 0XD581, 0X1540, 0XD701, 0X17C0,
-		0X1680, 0XD641, 0XD201, 0X12C0, 0X1380, 0XD341, 0X1100, 0XD1C1, 0XD081,
-		0X1040, 0XF001, 0X30C0, 0X3180, 0XF141, 0X3300, 0XF3C1, 0XF281, 0X3240,
-		0X3600, 0XF6C1, 0XF781, 0X3740, 0XF501, 0X35C0, 0X3480, 0XF441, 0X3C00,
-		0XFCC1, 0XFD81, 0X3D40, 0XFF01, 0X3FC0, 0X3E80, 0XFE41, 0XFA01, 0X3AC0,
-		0X3B80, 0XFB41, 0X3900, 0XF9C1, 0XF881, 0X3840, 0X2800, 0XE8C1, 0XE981,
-		0X2940, 0XEB01, 0X2BC0, 0X2A80, 0XEA41, 0XEE01, 0X2EC0, 0X2F80, 0XEF41,
-		0X2D00, 0XEDC1, 0XEC81, 0X2C40, 0XE401, 0X24C0, 0X2580, 0XE541, 0X2700,
-		0XE7C1, 0XE681, 0X2640, 0X2200, 0XE2C1, 0XE381, 0X2340, 0XE101, 0X21C0,
-		0X2080, 0XE041, 0XA001, 0X60C0, 0X6180, 0XA141, 0X6300, 0XA3C1, 0XA281,
-		0X6240, 0X6600, 0XA6C1, 0XA781, 0X6740, 0XA501, 0X65C0, 0X6480, 0XA441,
-		0X6C00, 0XACC1, 0XAD81, 0X6D40, 0XAF01, 0X6FC0, 0X6E80, 0XAE41, 0XAA01,
-		0X6AC0, 0X6B80, 0XAB41, 0X6900, 0XA9C1, 0XA881, 0X6840, 0X7800, 0XB8C1,
-		0XB981, 0X7940, 0XBB01, 0X7BC0, 0X7A80, 0XBA41, 0XBE01, 0X7EC0, 0X7F80,
-		0XBF41, 0X7D00, 0XBDC1, 0XBC81, 0X7C40, 0XB401, 0X74C0, 0X7580, 0XB541,
-		0X7700, 0XB7C1, 0XB681, 0X7640, 0X7200, 0XB2C1, 0XB381, 0X7340, 0XB101,
-		0X71C0, 0X7080, 0XB041, 0X5000, 0X90C1, 0X9181, 0X5140, 0X9301, 0X53C0,
-		0X5280, 0X9241, 0X9601, 0X56C0, 0X5780, 0X9741, 0X5500, 0X95C1, 0X9481,
-		0X5440, 0X9C01, 0X5CC0, 0X5D80, 0X9D41, 0X5F00, 0X9FC1, 0X9E81, 0X5E40,
-		0X5A00, 0X9AC1, 0X9B81, 0X5B40, 0X9901, 0X59C0, 0X5880, 0X9841, 0X8801,
-		0X48C0, 0X4980, 0X8941, 0X4B00, 0X8BC1, 0X8A81, 0X4A40, 0X4E00, 0X8EC1,
-		0X8F81, 0X4F40, 0X8D01, 0X4DC0, 0X4C80, 0X8C41, 0X4400, 0X84C1, 0X8581,
-		0X4540, 0X8701, 0X47C0, 0X4680, 0X8641, 0X8201, 0X42C0, 0X4380, 0X8341,
-		0X4100, 0X81C1, 0X8081, 0X4040
-	};
-
-	uint8_t nTemp;
-	uint16_t wCRCWord = 0xFFFF;
-
-	while (len--)
-	{
-		nTemp = *buff++ ^ wCRCWord;
-		wCRCWord >>= 8;
-		wCRCWord ^= wCRCTable[nTemp];
-	}
-	return wCRCWord;
-}
-
-void ModbusInstrument::SendCommand(ModbusFunction function, std::vector<uint8_t>* data)
+void ModbusInstrument::SendCommand(ModbusFunction function, const std::vector<uint8_t> &data)
 {
 	// Modbus query frame format is:
 	// | 1 byte slave adress | 1 byte command function # | n bytes of data | 2 bytes CRC |
 	std::vector<unsigned char> buffer;
 	buffer.push_back(m_slaveAdress);
 	buffer.push_back(function);
-	for(size_t i = 0 ; i < data->size() ; i++)
+	for(size_t i = 0 ; i < data.size() ; i++)
 	{
-		buffer.push_back((unsigned char)(*data)[i]);
+		buffer.push_back((unsigned char)data[i]);
 	}
 	uint16_t crc = CalculateCRC(buffer.begin().base(), buffer.size());
 	buffer.push_back(reinterpret_cast<const unsigned char *>(&crc)[0]);

--- a/scopehal/ModbusInstrument.h
+++ b/scopehal/ModbusInstrument.h
@@ -40,7 +40,7 @@
 	@brief Base class for instruments using Modbus communication protocol
 	@ingroup core
  */
-class ModbusInstrument 	: public virtual SCPIInstrument
+class ModbusInstrument 	: public virtual SCPIInstrument, public BinaryDriver
 {
 public:
 	ModbusInstrument(SCPITransport* transport, uint8_t slaveAdress=1);
@@ -75,12 +75,9 @@ protected:
 	std::recursive_mutex m_modbusMutex;
 
 	uint8_t m_slaveAdress;
-	uint16_t CalculateCRC(const uint8_t *buff, size_t len);
 	void Converse(ModbusFunction function, std::vector<uint8_t>* data);
-	void SendCommand(ModbusFunction function, std::vector<uint8_t>* data);
+	void SendCommand(ModbusFunction function, const std::vector<uint8_t> &data);
 	void ReadResponse(ModbusFunction function, std::vector<uint8_t>* data);
-	void PushUint16(std::vector<uint8_t>* data, uint16_t value);
-	uint16_t ReadUint16(std::vector<uint8_t>* data, uint8_t index);
 };
 
 #endif


### PR DESCRIPTION
Hi Andrew,

This is a small PR to end the job started with HID driver re. BinaryDriver helper class.
ModbusInstrument now uses BinaryDriver helper methods for push/read uint16 and CRC calculation.

Best,

Frederic.