### PR TITLE
tinySA and tinySA ULTRA driver

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -146,6 +146,7 @@ set(SCOPEHAL_SOURCES
 	SCPIOscilloscope.cpp
 	SCPIPowerSupply.cpp
 	SCPIRFSignalGenerator.cpp
+	SCPISA.cpp
 	SCPISDR.cpp
 	SCPISpectrometer.cpp
 	SCPIVNA.cpp
@@ -184,6 +185,7 @@ set(SCOPEHAL_SOURCES
 	TektronixOscilloscope.cpp
 	TektronixHSIOscilloscope.cpp
 	ThunderScopeOscilloscope.cpp
+	TinySA.cpp
 	UHDBridgeSDR.cpp
 	HP662xAPowerSupply.cpp
 	RigolDP8xxPowerSupply.cpp

--- a/scopehal/SCPISA.cpp
+++ b/scopehal/SCPISA.cpp
@@ -189,7 +189,7 @@ void SCPISA::SetSampleRate([[maybe_unused]] uint64_t rate)
 
 uint64_t SCPISA::GetSampleRate()
 {
-	return 1;
+	return 0;
 }
 
 unsigned int SCPISA::GetInstrumentTypes() const

--- a/scopehal/SCPISA.cpp
+++ b/scopehal/SCPISA.cpp
@@ -1,0 +1,231 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2024 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+#include "scopehal.h"
+#include "SCPISA.h"
+
+using namespace std;
+
+//SCPISA::VNACreateMapType SCPISA::m_vnacreateprocs;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+SCPISA::SCPISA()
+{
+}
+
+SCPISA::~SCPISA()
+{
+
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Enumeration
+/*
+void SCPISA::DoAddDriverClass(string name, VNACreateProcType proc)
+{
+	m_vnacreateprocs[name] = proc;
+}
+
+void SCPISA::EnumDrivers(vector<string>& names)
+{
+	for(auto it=m_vnacreateprocs.begin(); it != m_vnacreateprocs.end(); ++it)
+		names.push_back(it->first);
+}
+
+shared_ptr<SCPISA> SCPISA::CreateVNA(string driver, SCPITransport* transport)
+{
+	if(m_vnacreateprocs.find(driver) != m_vnacreateprocs.end())
+		return m_vnacreateprocs[driver](transport);
+
+	LogError("Invalid VNA driver name \"%s\"\n", driver.c_str());
+	return nullptr;
+}
+*/
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Default stubs for Oscilloscope methods
+
+bool SCPISA::IsChannelEnabled([[maybe_unused]]size_t i)
+{
+	return true;
+}
+
+void SCPISA::EnableChannel([[maybe_unused]]size_t i)
+{
+	//no-op
+}
+
+void SCPISA::DisableChannel([[maybe_unused]]size_t i)
+{
+	//no-op
+}
+
+OscilloscopeChannel::CouplingType SCPISA::GetChannelCoupling([[maybe_unused]]size_t i)
+{
+	//all inputs are ac coupled 50 ohm impedance
+	return OscilloscopeChannel::COUPLE_AC_50;
+}
+
+void SCPISA::SetChannelCoupling([[maybe_unused]]size_t i,[[maybe_unused]] OscilloscopeChannel::CouplingType type)
+{
+	//no-op, coupling cannot be changed
+}
+
+vector<OscilloscopeChannel::CouplingType> SCPISA::GetAvailableCouplings([[maybe_unused]]size_t i)
+{
+	vector<OscilloscopeChannel::CouplingType> ret;
+	ret.push_back(OscilloscopeChannel::COUPLE_AC_50);
+	return ret;
+}
+
+double SCPISA::GetChannelAttenuation([[maybe_unused]] size_t i)
+{
+	return 1;
+}
+
+void SCPISA::SetChannelAttenuation([[maybe_unused]] size_t i,[[maybe_unused]] double atten)
+{
+	//no-op
+}
+
+unsigned int SCPISA::GetChannelBandwidthLimit([[maybe_unused]] size_t i)
+{
+	return 0;
+}
+
+void SCPISA::SetChannelBandwidthLimit([[maybe_unused]] size_t i,[[maybe_unused]] unsigned int limit_mhz)
+{
+	//no-op
+}
+
+bool SCPISA::IsInterleaving()
+{
+	return false;
+}
+
+bool SCPISA::SetInterleaving([[maybe_unused]] bool combine)
+{
+	return false;
+}
+
+
+bool SCPISA::HasFrequencyControls()
+{
+	return true;
+}
+
+bool SCPISA::HasTimebaseControls()
+{
+	return false;
+}
+
+void SCPISA::SetTriggerOffset([[maybe_unused]] int64_t offset)
+{
+}
+
+int64_t SCPISA::GetTriggerOffset()
+{
+	return 0;
+}
+
+vector<uint64_t> SCPISA::GetSampleDepthsInterleaved()
+{
+	//interleaving not supported
+	vector<uint64_t> ret;
+	return ret;
+}
+
+vector<uint64_t> SCPISA::GetSampleRatesInterleaved()
+{
+	//interleaving not supported
+	vector<uint64_t> ret = {};
+	return ret;
+}
+
+set<Oscilloscope::InterleaveConflict> SCPISA::GetInterleaveConflicts()
+{
+	//interleaving not supported
+	set<Oscilloscope::InterleaveConflict> ret;
+	return ret;
+}
+
+vector<uint64_t> SCPISA::GetSampleRatesNonInterleaved()
+{
+	vector<uint64_t> ret;
+	ret.push_back(1);
+	return ret;
+}
+
+void SCPISA::SetSampleRate([[maybe_unused]] uint64_t rate)
+{
+}
+
+uint64_t SCPISA::GetSampleRate()
+{
+	return 1;
+}
+
+unsigned int SCPISA::GetInstrumentTypes() const
+{
+	return Instrument::INST_OSCILLOSCOPE;
+}
+
+uint32_t SCPISA::GetInstrumentTypesForChannel([[maybe_unused]] size_t i) const
+{
+	return Instrument::INST_OSCILLOSCOPE;
+}
+
+float SCPISA::GetChannelVoltageRange(size_t i, size_t stream)
+{
+	//range in cache is always valid
+	lock_guard<recursive_mutex> lock(m_cacheMutex);
+	return m_channelVoltageRange[pair<size_t, size_t>(i, stream)];
+}
+
+void SCPISA::SetChannelVoltageRange(size_t i, size_t stream, float range)
+{
+	//Range is entirely clientside, hardware is always full scale dynamic range
+	lock_guard<recursive_mutex> lock(m_cacheMutex);
+	m_channelVoltageRange[pair<size_t, size_t>(i, stream)]= range;
+}
+
+float SCPISA::GetChannelOffset(size_t i, size_t stream)
+{
+	//offset in cache is always valid
+	lock_guard<recursive_mutex> lock(m_cacheMutex);
+	return m_channelOffset[pair<size_t, size_t>(i, stream)];
+}
+
+void SCPISA::SetChannelOffset(size_t i, size_t stream, float offset)
+{
+	//Offset is entirely clientside, hardware is always full scale dynamic range
+	lock_guard<recursive_mutex> lock(m_cacheMutex);
+	m_channelOffset[pair<size_t, size_t>(i, stream)] = offset;
+}

--- a/scopehal/SCPISA.cpp
+++ b/scopehal/SCPISA.cpp
@@ -32,7 +32,7 @@
 
 using namespace std;
 
-//SCPISA::VNACreateMapType SCPISA::m_vnacreateprocs;
+//SCPISA::SACreateMapType SCPISA::m_vnacreateprocs;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Construction / destruction
@@ -49,7 +49,7 @@ SCPISA::~SCPISA()
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Enumeration
 /*
-void SCPISA::DoAddDriverClass(string name, VNACreateProcType proc)
+void SCPISA::DoAddDriverClass(string name, SACreateProcType proc)
 {
 	m_vnacreateprocs[name] = proc;
 }
@@ -60,12 +60,12 @@ void SCPISA::EnumDrivers(vector<string>& names)
 		names.push_back(it->first);
 }
 
-shared_ptr<SCPISA> SCPISA::CreateVNA(string driver, SCPITransport* transport)
+shared_ptr<SCPISA> SCPISA::CreateSA(string driver, SCPITransport* transport)
 {
 	if(m_vnacreateprocs.find(driver) != m_vnacreateprocs.end())
 		return m_vnacreateprocs[driver](transport);
 
-	LogError("Invalid VNA driver name \"%s\"\n", driver.c_str());
+	LogError("Invalid SA driver name \"%s\"\n", driver.c_str());
 	return nullptr;
 }
 */

--- a/scopehal/SCPISA.cpp
+++ b/scopehal/SCPISA.cpp
@@ -229,3 +229,83 @@ void SCPISA::SetChannelOffset(size_t i, size_t stream, float offset)
 	lock_guard<recursive_mutex> lock(m_cacheMutex);
 	m_channelOffset[pair<size_t, size_t>(i, stream)] = offset;
 }
+
+// Trigger management
+
+OscilloscopeChannel* SCPISA::GetExternalTrigger()
+{
+	return NULL;
+}
+
+Oscilloscope::TriggerMode SCPISA::PollTrigger()
+{
+	return m_triggerArmed ? TRIGGER_MODE_TRIGGERED : TRIGGER_MODE_STOP;
+}
+void SCPISA::Start()
+{
+	m_triggerArmed = true;
+	m_triggerOneShot = false;
+}
+
+void SCPISA::StartSingleTrigger()
+{
+	m_triggerArmed = true;
+	m_triggerOneShot = true;
+}
+
+void SCPISA::Stop()
+{
+	m_triggerArmed = false;
+	m_triggerOneShot = false;
+}
+
+void SCPISA::ForceTrigger()
+{
+	m_triggerArmed = true;
+	m_triggerOneShot = true;
+}
+
+bool SCPISA::IsTriggerArmed()
+{
+	return m_triggerArmed;
+}
+
+void SCPISA::PullTrigger()
+{
+	//pulling not needed, we always have a valid trigger cached
+}
+
+void SCPISA::PushTrigger()
+{
+	//do nothing
+}
+
+// Sample depth management
+
+vector<uint64_t> SCPISA::GetSampleDepthsNonInterleaved()
+{
+	vector<uint64_t> ret;
+	return ret;
+}
+
+uint64_t SCPISA::GetSampleDepth()
+{
+	return m_sampleDepth;
+}
+
+void SCPISA::SetSampleDepth(uint64_t depth)
+{
+	m_sampleDepth = depth;
+}
+
+// RBW management
+int64_t SCPISA::GetResolutionBandwidth()
+{
+	return m_rbw;
+}
+
+void SCPISA::SetResolutionBandwidth(int64_t rbw)
+{	
+	m_rbw = rbw;
+}
+

--- a/scopehal/SCPISA.h
+++ b/scopehal/SCPISA.h
@@ -110,24 +110,24 @@ protected:
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Dynamic creation
 public:
-	//typedef std::shared_ptr<SCPISA> (*VNACreateProcType)(SCPITransport*);
-	//static void DoAddDriverClass(std::string name, VNACreateProcType proc);
+	//typedef std::shared_ptr<SCPISA> (*SACreateProcType)(SCPITransport*);
+	//static void DoAddDriverClass(std::string name, SACreateProcType proc);
 
 	//static void EnumDrivers(std::vector<std::string>& names);
-	//static std::shared_ptr<SCPISA> CreateVNA(std::string driver, SCPITransport* transport);
+	//static std::shared_ptr<SCPISA> CreateSA(std::string driver, SCPITransport* transport);
 
 	//Class enumeration
-	//typedef std::map< std::string, VNACreateProcType > VNACreateMapType;
-	//static VNACreateMapType m_vnacreateprocs;
+	//typedef std::map< std::string, SACreateProcType > SACreateMapType;
+	//static SACreateMapType m_vnacreateprocs;
 };
 
 /*
-#define VNA_INITPROC(T) \
+#define SA_INITPROC(T) \
 	static std::shared_ptr<SCPISA> CreateInstance(SCPITransport* transport) \
 	{	return std::make_shared<T>(transport); } \
 	virtual std::string GetDriverName() const override \
 	{ return GetDriverNameInternal(); }
 
-#define AddVNADriverClass(T) SCPISA::DoAddDriverClass(T::GetDriverNameInternal(), T::CreateInstance)
+#define AddSADriverClass(T) SCPISA::DoAddDriverClass(T::GetDriverNameInternal(), T::CreateInstance)
 */
 #endif

--- a/scopehal/SCPISA.h
+++ b/scopehal/SCPISA.h
@@ -64,24 +64,48 @@ public:
 	virtual float GetChannelOffset(size_t i, size_t stream) override;
 	virtual void SetChannelOffset(size_t i, size_t stream, float offset) override;
 
+	//Triggering
+	virtual OscilloscopeChannel* GetExternalTrigger() override;
+	virtual Oscilloscope::TriggerMode PollTrigger() override;
+	virtual void Start() override;
+	virtual void StartSingleTrigger() override;
+	virtual void Stop() override;
+	virtual void ForceTrigger() override;
+	virtual bool IsTriggerArmed() override;
+	virtual void PushTrigger() override;
+	virtual void PullTrigger() override;
+
 	//Timebase
 	virtual std::set<InterleaveConflict> GetInterleaveConflicts() override;
-	virtual std::vector<uint64_t> GetSampleRatesInterleaved() override;
 	virtual std::vector<uint64_t> GetSampleDepthsInterleaved() override;
+	virtual std::vector<uint64_t> GetSampleDepthsNonInterleaved() override;
+	virtual uint64_t GetSampleDepth() override;
+	virtual void SetSampleDepth(uint64_t depth) override;
+	virtual std::vector<uint64_t> GetSampleRatesInterleaved() override;
+	virtual std::vector<uint64_t> GetSampleRatesNonInterleaved() override;
+	virtual uint64_t GetSampleRate() override;
+	virtual void SetSampleRate(uint64_t rate) override;
 	virtual void SetTriggerOffset(int64_t offset) override;
 	virtual int64_t GetTriggerOffset() override;
 	virtual bool IsInterleaving() override;
 	virtual bool SetInterleaving(bool combine) override;
-	virtual std::vector<uint64_t> GetSampleRatesNonInterleaved() override;
-	virtual uint64_t GetSampleRate() override;
-	virtual void SetSampleRate(uint64_t rate) override;
 
 	virtual bool HasFrequencyControls() override;
 	virtual bool HasTimebaseControls() override;
 
+	virtual void SetResolutionBandwidth(int64_t rbw);
+	virtual int64_t GetResolutionBandwidth() override;
+
 protected:
 	std::map<std::pair<size_t, size_t>, float> m_channelVoltageRange;
 	std::map<std::pair<size_t, size_t>, float> m_channelOffset;
+
+	bool m_triggerArmed = false;
+	bool m_triggerOneShot = false;
+
+	int64_t m_sampleDepth = 0;
+	int64_t m_rbw = 0;
+
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Dynamic creation

--- a/scopehal/SCPISA.h
+++ b/scopehal/SCPISA.h
@@ -1,0 +1,109 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2024 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Frederic Borry
+	@brief Declaration of SA
+ */
+
+#ifndef SCPISA_h
+#define SCPISA_h
+
+/**
+	@brief Generic representation of a Spectrum Analyzer
+ */
+class SCPISA : public virtual SCPIOscilloscope
+{
+public:
+	SCPISA();
+	virtual ~SCPISA();
+
+	virtual unsigned int GetInstrumentTypes() const override;
+	virtual uint32_t GetInstrumentTypesForChannel(size_t i) const override;
+
+	//Channel configuration
+	virtual bool IsChannelEnabled(size_t i) override;
+	virtual void EnableChannel(size_t i) override;
+	virtual void DisableChannel(size_t i) override;
+	virtual OscilloscopeChannel::CouplingType GetChannelCoupling(size_t i) override;
+	virtual void SetChannelCoupling(size_t i, OscilloscopeChannel::CouplingType type) override;
+	virtual std::vector<OscilloscopeChannel::CouplingType> GetAvailableCouplings(size_t i) override;
+	virtual double GetChannelAttenuation(size_t i) override;
+	virtual void SetChannelAttenuation(size_t i, double atten) override;
+	virtual unsigned int GetChannelBandwidthLimit(size_t i) override;
+	virtual void SetChannelBandwidthLimit(size_t i, unsigned int limit_mhz) override;
+	virtual float GetChannelVoltageRange(size_t i, size_t stream) override;
+	virtual void SetChannelVoltageRange(size_t i, size_t stream, float range) override;
+	virtual float GetChannelOffset(size_t i, size_t stream) override;
+	virtual void SetChannelOffset(size_t i, size_t stream, float offset) override;
+
+	//Timebase
+	virtual std::set<InterleaveConflict> GetInterleaveConflicts() override;
+	virtual std::vector<uint64_t> GetSampleRatesInterleaved() override;
+	virtual std::vector<uint64_t> GetSampleDepthsInterleaved() override;
+	virtual void SetTriggerOffset(int64_t offset) override;
+	virtual int64_t GetTriggerOffset() override;
+	virtual bool IsInterleaving() override;
+	virtual bool SetInterleaving(bool combine) override;
+	virtual std::vector<uint64_t> GetSampleRatesNonInterleaved() override;
+	virtual uint64_t GetSampleRate() override;
+	virtual void SetSampleRate(uint64_t rate) override;
+
+	virtual bool HasFrequencyControls() override;
+	virtual bool HasTimebaseControls() override;
+
+protected:
+	std::map<std::pair<size_t, size_t>, float> m_channelVoltageRange;
+	std::map<std::pair<size_t, size_t>, float> m_channelOffset;
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Dynamic creation
+public:
+	//typedef std::shared_ptr<SCPISA> (*VNACreateProcType)(SCPITransport*);
+	//static void DoAddDriverClass(std::string name, VNACreateProcType proc);
+
+	//static void EnumDrivers(std::vector<std::string>& names);
+	//static std::shared_ptr<SCPISA> CreateVNA(std::string driver, SCPITransport* transport);
+
+	//Class enumeration
+	//typedef std::map< std::string, VNACreateProcType > VNACreateMapType;
+	//static VNACreateMapType m_vnacreateprocs;
+};
+
+/*
+#define VNA_INITPROC(T) \
+	static std::shared_ptr<SCPISA> CreateInstance(SCPITransport* transport) \
+	{	return std::make_shared<T>(transport); } \
+	virtual std::string GetDriverName() const override \
+	{ return GetDriverNameInternal(); }
+
+#define AddVNADriverClass(T) SCPISA::DoAddDriverClass(T::GetDriverNameInternal(), T::CreateInstance)
+*/
+#endif

--- a/scopehal/TinySA.cpp
+++ b/scopehal/TinySA.cpp
@@ -51,10 +51,6 @@ using namespace std;
 TinySA::TinySA(SCPITransport* transport)
 	: SCPIDevice(transport,false)
 	, SCPIInstrument(transport,false)
-	, m_triggerArmed(false)
-	, m_triggerOneShot(false)
-	, m_sampleDepth(0)
-	, m_rbw(0)
 {
 	std::vector<string> info;
 	string version =  ConverseSingle("version");
@@ -352,17 +348,6 @@ string TinySA::GetDriverNameInternal()
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Device interface functions
 
-OscilloscopeChannel* TinySA::GetExternalTrigger()
-{
-	return NULL;
-}
-
-Oscilloscope::TriggerMode TinySA::PollTrigger()
-{
-	//Always report "triggered" so we can block on AcquireData() in ScopeThread
-	return TRIGGER_MODE_TRIGGERED;
-}
-
 bool TinySA::AcquireData()
 {
 	// LogDebug("Acquiring data\n");
@@ -446,36 +431,6 @@ bool TinySA::AcquireData()
 	return true;
 }
 
-
-void TinySA::Start()
-{
-	m_triggerArmed = true;
-	m_triggerOneShot = false;
-}
-
-void TinySA::StartSingleTrigger()
-{
-	m_triggerArmed = true;
-	m_triggerOneShot = true;
-}
-
-void TinySA::Stop()
-{
-	m_triggerArmed = false;
-	m_triggerOneShot = false;
-}
-
-void TinySA::ForceTrigger()
-{
-	m_triggerArmed = true;
-	m_triggerOneShot = true;
-}
-
-bool TinySA::IsTriggerArmed()
-{
-	return m_triggerArmed;
-}
-
 vector<uint64_t> TinySA::GetSampleDepthsNonInterleaved()
 {
 	vector<uint64_t> ret;
@@ -491,33 +446,8 @@ vector<uint64_t> TinySA::GetSampleDepthsNonInterleaved()
 	return ret;
 }
 
-uint64_t TinySA::GetSampleDepth()
-{
-	return m_sampleDepth;
-}
-
-void TinySA::SetSampleDepth(uint64_t depth)
-{
-	m_sampleDepth = depth;
-}
-
-void TinySA::PullTrigger()
-{
-	//pulling not needed, we always have a valid trigger cached
-}
-
-void TinySA::PushTrigger()
-{
-	//do nothing
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Spectrum analyzer mode
-
-int64_t TinySA::GetResolutionBandwidth()
-{
-	return m_rbw;
-}
 
 void TinySA::SetResolutionBandwidth(int64_t rbw)
 {	

--- a/scopehal/TinySA.cpp
+++ b/scopehal/TinySA.cpp
@@ -113,7 +113,13 @@ TinySA::~TinySA()
 {
 }
 
-
+/**
+ * @brief Converse with the device : send a command and read the reply over several lines
+ * 
+ * @param commandString the command string to send
+ * @param readLines a verctor to store the reply lines
+ * @return size_t the number of lines received from the device
+ */
 size_t TinySA::ConverseMultiple(const std::string commandString, std::vector<string> &readLines)
 {
 	stringstream ss(ConverseString(commandString));
@@ -141,6 +147,12 @@ size_t TinySA::ConverseMultiple(const std::string commandString, std::vector<str
 	return size;
 }
 
+/**
+ * @brief Converse with the device by sending a command and receiving a single line response
+ * 
+ * @param commandString the command string to send
+ * @return std::string the received response
+ */
 std::string TinySA::ConverseSingle(const std::string commandString)
 {
 	stringstream ss(ConverseString(commandString));
@@ -158,6 +170,12 @@ std::string TinySA::ConverseSingle(const std::string commandString)
 	return result;
 }
 
+/**
+ * @brief Base method to converse with the device
+ * 
+ * @param commandString the command string to send to the device
+ * @return std::string a string containing all the response from the device (may contain several lines separated by \r \n)
+ */
 std::string TinySA::ConverseString(const std::string commandString)
 {
 	string result = "";
@@ -196,6 +214,14 @@ std::string TinySA::ConverseString(const std::string commandString)
 	return result;
 }
 
+/**
+ * @brief Special method used to converse with the device with a binary response (e.g. spanraw command)
+ * 
+ * @param commandString the command string to send
+ * @param data a vector to store the binary data received from the device
+ * @param length the length of binary data expected from the device
+ * @return size_t the number of bytes actually read from the device
+ */
 size_t TinySA::ConverseBinary(const std::string commandString, std::vector<uint8_t> &data, size_t length)
 {
 	string header;
@@ -270,6 +296,13 @@ size_t TinySA::ConverseBinary(const std::string commandString, std::vector<uint8
 	return dataRead;
 }
 
+/**
+ * @brief Set and/or read the rbw value from the device
+ * 
+ * @param sendValue true if the rbw value hase to be set
+ * @param value the value to set
+ * @return int64_t the rbw value read from the device
+ */
 int64_t TinySA::ConverseRbwValue(bool sendValue, int64_t value)
 {
 	size_t lines;
@@ -300,6 +333,14 @@ int64_t TinySA::ConverseRbwValue(bool sendValue, int64_t value)
 	return isKhz ? (rbw*1000) : rbw;
 }
 
+/**
+ * @brief Set and/or read the sweep values from the device
+ * 
+ * @param sweepStart the sweep start value (in/out)
+ * @param sweepStop the sweep stop value (in/out)
+ * @param setValue tru is the values have to be set on the device
+ * @return true is the value returned by the device is different from the one that shoudl have been set (e.g. out of range)
+ */
 bool TinySA::ConverseSweep(int64_t &sweepStart, int64_t &sweepStop, bool setValue)
 {
 	size_t lines;
@@ -342,7 +383,7 @@ bool TinySA::ConverseSweep(int64_t &sweepStart, int64_t &sweepStop, bool setValu
 ///@brief Return the constant driver name string "tektronix"
 string TinySA::GetDriverNameInternal()
 {
-	return "tiny-sa";
+	return "tiny_sa";
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scopehal/TinySA.cpp
+++ b/scopehal/TinySA.cpp
@@ -518,7 +518,6 @@ void TinySA::SetResolutionBandwidth(int64_t rbw)
 
 void TinySA::SetSpan(int64_t span)
 {
-	lock_guard<recursive_mutex> lock(m_cacheMutex);
 	//Calculate requested start/stop
 	auto freq = GetCenterFrequency(0);
 	m_sweepStart = freq - span/2;
@@ -539,7 +538,6 @@ int64_t TinySA::GetSpan()
 
 void TinySA::SetCenterFrequency([[maybe_unused]] size_t channel, int64_t freq)
 {
-	lock_guard<recursive_mutex> lock(m_cacheMutex);
 	//Calculate requested start/stop
 	int64_t span = GetSpan();
 	m_sweepStart = freq - span/2;

--- a/scopehal/TinySA.cpp
+++ b/scopehal/TinySA.cpp
@@ -408,8 +408,8 @@ bool TinySA::AcquireData()
 	pending_waveforms[0].push_back(cap);
 
 	//Look for peaks
-	//TODO: make this configurable, for now 1 MHz spacing and up to 10 peaks
-	dynamic_cast<SpectrumChannel*>(m_channels[0])->FindPeaks(cap, 10, 1000000);
+	//TODO: make this configurable, for now 500 kHz spacing and up to 10 peaks
+	dynamic_cast<SpectrumChannel*>(m_channels[0])->FindPeaks(cap, 10, 500000);
 
 	//Now that we have all of the pending waveforms, save them in sets across all channels
 	m_pendingWaveformsMutex.lock();

--- a/scopehal/TinySA.cpp
+++ b/scopehal/TinySA.cpp
@@ -53,9 +53,7 @@ TinySA::TinySA(SCPITransport* transport)
 	, SCPIInstrument(transport,false)
 	, m_triggerArmed(false)
 	, m_triggerOneShot(false)
-	, m_sampleDepthValid(false)
 	, m_sampleDepth(0)
-	, m_rbwValid(false)
 	, m_rbw(0)
 {
 	std::vector<string> info;
@@ -65,12 +63,19 @@ TinySA::TinySA(SCPITransport* transport)
 		LogError("Could not connect to TinySA :-/\n");
 		return;
 	}
+	// Set vendor and version
 	m_vendor= "tinySA";
+	m_fwVersion = version;
+	LogDebug("Version = %s\n",m_fwVersion.c_str());
+
 	// Get model out of first line of info command response
 	m_model= ConverseSingle("info");
 	LogDebug("Model = %s\n",m_model.c_str());
-	m_fwVersion = version;
-	LogDebug("Version = %s\n",m_fwVersion.c_str());
+	if(m_model.find("ULTRA")!= std::string::npos)
+		m_tinySAModel = Model::TINY_SA_ULTRA;
+	else
+		m_tinySAModel = Model::TINY_SA;
+
 	//Add spectrum view channel
 	m_channels.push_back(
 		new SpectrumChannel(
@@ -78,7 +83,36 @@ TinySA::TinySA(SCPITransport* transport)
 		string("CH1"),
 		string("#ffff00"),
 		m_channels.size()));
-	// Get span information
+
+	// Default memory depth to 1000 points
+	m_sampleDepth = 1000;
+	switch (m_tinySAModel)
+	{
+		case TINY_SA_ULTRA:
+			m_freqMin = 1000000L; 		//100kHz
+			m_freqMax = 6000000000L;	//6GHz
+			m_rbwMin  = 200L; 			//200Hz
+			m_rbwMax  = 850000L;		//850kHz
+			m_modelDbmOffset = 174;
+			break;
+		case TINY_SA:
+			m_freqMin = 1000000L; 		//100kHz
+			m_freqMax = 350000000L;		//350MHz
+			m_rbwMin  = 1L; 			//1kHz
+			m_rbwMax  = 600000L;		//600kHz
+			m_modelDbmOffset = 128;
+		default:
+			break;
+	}
+	// Get span information, format is "<start> <stop> <points>"
+	string sweep = ConverseSingle("sweep");
+	sscanf(sweep.c_str(), "%lld %lld", &m_sweepStart, &m_sweepStop);
+	LogDebug("Found sweep start %lld / stop %lld\n",m_sweepStart,m_sweepStop);
+	// Read rbw
+	m_rbw = ConverseRbwValue();
+	// Init channel range and offet
+	SetChannelVoltageRange(0,0,130);
+	SetChannelOffset(0,0,50);
 }
 
 TinySA::~TinySA()
@@ -89,20 +123,23 @@ TinySA::~TinySA()
 size_t TinySA::ConverseMultiple(const std::string commandString, std::vector<string> &readLines)
 {
 	stringstream ss(ConverseString(commandString));
-	string result;
 	string curLine;
 	bool firstLine = true;
 	size_t size = 0;
     while (getline(ss, curLine)) 
 	{
+		// Remove remaining \r
+		RemoveCR(curLine);
 		if(firstLine)
 		{
-			//if(curLine.compare(commandString) != 0)
-			//	LogWarning("Unexpected response '%s' to command string '%s'.\n",curLine.c_str(),commandString.c_str());
+			// First line is always an echo of the sent command
+			if(curLine.compare(commandString) != 0)
+				LogWarning("Unexpected response \"%s\" to command string \"%s\".\n",curLine.c_str(),commandString.c_str());
 			firstLine = false;
 		}
         else if (!curLine.empty()) 
 		{
+			LogDebug("Pusshing back line \"%s\".\n",curLine.c_str());
             readLines.push_back(curLine);
 			size++;
         }
@@ -116,10 +153,14 @@ std::string TinySA::ConverseSingle(const std::string commandString)
 	string result;
 	// Read first line (echo of command string)
 	getline(ss,result);
-	//if(result.compare(commandString) != 0)
-	//	LogWarning("Unexpected response '%s' to command string '%s'.\n",result.c_str(),commandString.c_str());
+	// Remove remaining \r
+	RemoveCR(result);
+	if(result.compare(commandString) != 0)
+		LogWarning("Unexpected response \"%s\" to command string \"%s\".\n",result.c_str(),commandString.c_str());
 	// Get second line as result
 	getline(ss,result);
+	// Remove remaining \r
+	RemoveCR(result);
 	return result;
 }
 
@@ -150,10 +191,97 @@ std::string TinySA::ConverseString(const std::string commandString)
 	return result;
 }
 
-size_t TinySA::ConverseBinary(const std::string commandString, std::vector<uint8_t> &data)
+size_t TinySA::ConverseBinary(const std::string commandString, std::vector<uint8_t> &data, size_t length)
 {
-	return 0;
+	string header;
+	bool inHeader = true;
+	bool inFooter = false;
+	string result;
+	// Lock guard
+	lock_guard<recursive_mutex> lock(m_transportMutex);
+	m_transport->SendCommand(commandString+"\r\n");
+	// Read untill we get  "ch>\r\n"
+	char tmp = ' ';
+	size_t bytesRead = 0;
+	size_t dataRead = 0;
+	// Prepare buffer size
+	data.resize(length);
+	while(true)
+	{	
+		if(inFooter || inHeader)
+		{
+			// Consume header and footer as strings
+			if(!m_transport->ReadRawData(1,(unsigned char*)&tmp))
+			{
+				// We might have to wait for the sweep to start to get a response
+				// TODO timeout
+				continue;
+			}
+			bytesRead++;
+			if(bytesRead > MAX_RESPONSE_SIZE)
+			{
+				LogError("Error while reading data from TinySA: response too long (%zu bytes).\n",bytesRead);
+				break;
+			}
+			if(inHeader)
+			{
+				result += tmp;
+				if(result.size()>=EOL_STRING_LENGTH && (0 == result.compare (result.length() - EOL_STRING_LENGTH, EOL_STRING_LENGTH, EOL_STRING)))
+				{
+					inHeader = false;
+					// Check that header matches command string
+					if(result.rfind(commandString,0) != 0)
+						LogWarning("Unexpected response \"%s\" to command string \"%s\".\n",result.c_str(),commandString.c_str());
+					result = "";
+				}
+			}
+			else if (inFooter)
+			{
+				result += tmp;
+				if(result.size()>=TRAILER_STRING_LENGTH && (0 == result.compare (result.length() - TRAILER_STRING_LENGTH, TRAILER_STRING_LENGTH, TRAILER_STRING)))
+					break;
+			}
+		}
+		else
+		{
+			// Read binary data
+			dataRead += m_transport->ReadRawData(length,data.begin().base(),[this] (float progress) { ChannelsDownloadStatusUpdate(0, InstrumentChannel::DownloadState::DOWNLOAD_IN_PROGRESS, progress); });
+			if(dataRead >= length)
+				inFooter = true;
+			// TODO tiemout
+		}
+	}
+	return dataRead;
 }
+
+int64_t TinySA::ConverseRbwValue(bool sendValue, int64_t value)
+{
+	size_t lines;
+	vector<string> reply;
+	if(sendValue)
+	{
+		lines = ConverseMultiple("rbw "+std::to_string(value),reply);
+		if(lines > 1)
+		{	// Value was rejected
+			LogWarning("Error while sending rbw value %lld: \"%s\".\n",value,reply[0].c_str());
+			// Clear reply for next use
+			reply.clear();
+		}
+	}
+	// Get currently configured rbw
+	lines = ConverseMultiple("rbw",reply);
+	if(lines < 2)
+	{
+		LogWarning("Error while requesting rbw: returned only %zu lines.\n",lines);
+		return 0;
+	}
+	// First line is for usage, get the actual rbw value from second line
+	int64_t rbw;
+	sscanf(reply[1].c_str(), "%lldkHz", &rbw);
+	LogDebug("Found rbw value = %lld\n",rbw);
+	return rbw;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Accessors
@@ -178,103 +306,69 @@ Oscilloscope::TriggerMode TinySA::PollTrigger()
 	return TRIGGER_MODE_TRIGGERED;
 }
 
-void TinySA::FlushConfigCache()
-{
-	SCPISA::FlushConfigCache();
-	m_sampleDepthValid = false;
-}
-
 bool TinySA::AcquireData()
 {
-	//LogDebug("Acquiring data\n");
+	// LogDebug("Acquiring data\n");
+	// Store sample depth value
+	size_t nsamples = m_sampleDepth;
+	string command = "scanraw " + std::to_string(m_sweepStart) + " " + std::to_string(m_sweepStop) + " " + std::to_string(nsamples);
+	std::vector<uint8_t> data;
+	// Data format is  '{' ('x' MSB LSB)*points '}'
+	size_t toRead = nsamples * 3 + 2;
+	size_t read = ConverseBinary(command,data,toRead);
+	if(read != toRead)
+	{
+		LogError("Invalid number of acquired bytes: %zu, expected %zu. Ingoring capture.\n",read,toRead);
+		return false;
+	}
 
-/*	map<int, vector<WaveformBase*> > pending_waveforms;
+	map<int, vector<WaveformBase*> > pending_waveforms;
 
-	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+	int64_t stepsize = (m_sweepStop - m_sweepStart) / nsamples;
 
-			// Set source (before setting format)
-			m_transport->SendCommandImmediate(string("DAT:SOU ") + GetOscilloscopeChannel(i)->GetHwname() + "_SV_NORMAL");
+	double tstart = GetTime();
+	int64_t fs = (tstart - floor(tstart)) * FS_PER_SECOND;
 
-			//Select mode
-			if(firstSpectrum || retry) // set again on retry
-			{
-				m_transport->SendCommandImmediate("DAT:WID 8");					//double precision floating point data
-				m_transport->SendCommandImmediate("DAT:ENC SFPB");				//IEEE754 float
-				firstSpectrum = false;
-			}
+	//Set up the capture we're going to store our data into
+	auto cap = new UniformAnalogWaveform;
+	cap->m_timescale = stepsize;
+	cap->m_triggerPhase = m_sweepStart;
+	cap->m_startTimestamp = floor(tstart);
+	cap->m_startFemtoseconds = fs;
+	cap->Resize(nsamples);
+	cap->PrepareForCpuAccess();
 
-			//Ask for the waveform preamble
-			string preamble_str = m_transport->SendCommandImmediateWithReply("WFMO?", false);
-			mso56_preamble preamble;
+	// Check data opening and closing brackets
+	if(data[0] != '{')
+		LogWarning("Invalid opening byte '%02x'.\n",data[0]);
+	if(data[toRead-1] != '}')
+		LogWarning("Invalid closing byte '%02x'.\n",data[toRead-1]);
 
-			//LogDebug("Channel %zu (%s)\n", nchan, m_channels[nchan]->GetHwname().c_str());
-			//LogIndenter li2;
+	//We get dBm from the instrument, so just have to convert double to single precision
+	for(size_t j=0; j<nsamples; j++)
+	{
+		// Read content (3 bytes per point, skipping first byte)
+		uint8_t data0 = data[1+3*j];
+		uint16_t data1 = (uint16_t)data[2+3*j];
+		uint16_t data2 = (uint16_t)data[3+3*j]; 
+		if(data0 != 'x')
+			LogWarning("Invalid point header byte '%02x'.\n",data0);
+		float value = (((float)((data2 << 8) + data1))/32)-m_modelDbmOffset;
+		//LogDebug("Value[%zu] = %02x%02x = %f\n",j,data1,data2,value);
+		cap->m_samples[j] = value;
+	}
 
-			//Process it
-			if (!ReadPreamble(preamble_str, preamble))
-				continue; // retry
+	//Done, update the data
+	cap->MarkSamplesModifiedFromCpu();
+	pending_waveforms[0].push_back(cap);
 
-			m_channelOffsets[i] = -preamble.yoff;
-
-			//Read the data block
-			size_t msglen;
-			double* samples = (double*)m_transport->SendCommandImmediateWithRawBlockReply("CURV?", msglen);
-			if(samples == NULL)
-			{
-				LogWarning("Didn't get any samples (timeout?)\n");
-
-				ResynchronizeSCPI();
-
-				continue; // retry
-			}
-
-			size_t nsamples = msglen/8;
-
-			if (nsamples != (size_t)preamble.nr_pt)
-			{
-				LogWarning("Didn't get the right number of points\n");
-
-				ResynchronizeSCPI();
-
-				delete[] samples;
-
-				continue; // retry
-			}
-
-			//Set up the capture we're going to store our data into
-			//(no TDC data or fine timestamping available on Tektronix scopes?)
-			auto cap = new UniformAnalogWaveform;
-			cap->m_timescale = preamble.hzbase;
-			cap->m_triggerPhase = 0;
-			cap->m_startTimestamp = time(NULL);
-			double t = GetTime();
-			cap->m_startFemtoseconds = (t - floor(t)) * FS_PER_SECOND;
-			cap->Resize(nsamples);
-			cap->PrepareForCpuAccess();
-
-			//We get dBm from the instrument, so just have to convert double to single precision
-			//TODO: are other units possible here?
-			//int64_t ibase = preamble.hzoff / preamble.hzbase;
-			for(size_t j=0; j<nsamples; j++)
-				cap->m_samples[j] = preamble.ymult*samples[j] + preamble.yoff;
-
-			//Done, update the data
-			cap->MarkSamplesModifiedFromCpu();
-			pending_waveforms[nchan].push_back(cap);
-
-			//Done
-			delete[] samples;
-
-			//Throw out garbage at the end of the message (why is this needed?)
-			m_transport->ReadReply();
-
-			//Look for peaks
-			//TODO: make this configurable, for now 1 MHz spacing and up to 10 peaks
-			dynamic_cast<SpectrumChannel*>(m_channels[nchan])->FindPeaks(cap, 10, 1000000);
+	//Look for peaks
+	//TODO: make this configurable, for now 1 MHz spacing and up to 10 peaks
+	dynamic_cast<SpectrumChannel*>(m_channels[0])->FindPeaks(cap, 10, 1000000);
 
 	//Now that we have all of the pending waveforms, save them in sets across all channels
 	m_pendingWaveformsMutex.lock();
-	size_t num_pending = 1;	//TODO: segmented capture support
+	size_t num_pending = 1;
 	for(size_t i=0; i<num_pending; i++)
 	{
 		SequenceSet s;
@@ -287,17 +381,11 @@ bool TinySA::AcquireData()
 	}
 	m_pendingWaveformsMutex.unlock();
 
-	//Re-arm the trigger if not in one-shot mode
-	if(!m_triggerOneShot)
-	{
-		lock_guard<recursive_mutex> lock3(m_cacheMutex);
-		FlushChannelEnableStates();
-
-		m_transport->SendCommandImmediate("ACQ:STATE ON");
-		m_triggerArmed = true;
-	}
-*/
+	if(m_triggerOneShot)
+		m_triggerArmed = false;
 	//LogDebug("Acquisition done\n");
+	// Tell the download monitor that waveform download has finished
+	ChannelsDownloadFinished();
 	return true;
 }
 
@@ -348,16 +436,12 @@ vector<uint64_t> TinySA::GetSampleDepthsNonInterleaved()
 
 uint64_t TinySA::GetSampleDepth()
 {
-	if(!m_sampleDepthValid)
-	{
-		m_sampleDepth = 0;
-		m_sampleDepthValid = true;
-	}
 	return m_sampleDepth;
 }
 
 void TinySA::SetSampleDepth(uint64_t depth)
 {
+	m_sampleDepth = depth;
 }
 
 void TinySA::PullTrigger()
@@ -380,25 +464,43 @@ int64_t TinySA::GetResolutionBandwidth()
 
 void TinySA::SetResolutionBandwidth(int64_t rbw)
 {	
-	m_rbw = rbw;
-	m_rbwValid = true;
-	// TODO
+	//Clamp to instrument limits
+	m_rbw = max(m_rbwMin, rbw);
+	m_rbw = min(m_rbwMax, m_rbw);
+	// Send rbw in kHz and read actual return
+	m_rbw = ConverseRbwValue(true, (m_rbw/1000));
 }
 
-void TinySA::SetSpan([[maybe_unused]] int64_t span)
-{	// TODO
+void TinySA::SetSpan(int64_t span)
+{
+	//Calculate requested start/stop
+	auto freq = GetCenterFrequency(0);
+	m_sweepStart = freq - span/2;
+	m_sweepStop = freq + span/2;
+
+	//Clamp to instrument limits
+	m_sweepStart = max(m_freqMin, m_sweepStart);
+	m_sweepStop = min(m_freqMax, m_sweepStop);
 }
 
 int64_t TinySA::GetSpan()
 {	// TODO
-	return 0;
+	return m_sweepStop - m_sweepStart;
 }
 
-void TinySA::SetCenterFrequency([[maybe_unused]] size_t channel,[[maybe_unused]] int64_t freq)
+void TinySA::SetCenterFrequency([[maybe_unused]] size_t channel, int64_t freq)
 {	// TODO
+	//Calculate requested start/stop
+	int64_t span = GetSpan();
+	m_sweepStart = freq - span/2;
+	m_sweepStop = freq + span/2;
+
+	//Clamp to instrument limits
+	m_sweepStart = max(m_freqMin, m_sweepStart);
+	m_sweepStop = min(m_freqMax, m_sweepStop);
 }
 
 int64_t TinySA::GetCenterFrequency([[maybe_unused]] size_t channel)
-{	// TODO
-	return 0;
+{
+	return (m_sweepStop + m_sweepStart) / 2;
 }

--- a/scopehal/TinySA.cpp
+++ b/scopehal/TinySA.cpp
@@ -1,0 +1,404 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2024 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Frederic Borry
+	@brief Implementation of TinySA
+
+	@ingroup scopedrivers
+ */
+
+#include "scopehal.h"
+#include "TinySA.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+/**
+	@brief Initialize the driver
+
+	@param transport	SCPITransport connected to the SA
+ */
+TinySA::TinySA(SCPITransport* transport)
+	: SCPIDevice(transport,false)
+	, SCPIInstrument(transport,false)
+	, m_triggerArmed(false)
+	, m_triggerOneShot(false)
+	, m_sampleDepthValid(false)
+	, m_sampleDepth(0)
+	, m_rbwValid(false)
+	, m_rbw(0)
+{
+	std::vector<string> info;
+	string version =  ConverseSingle("version");
+	if(version.empty())
+	{
+		LogError("Could not connect to TinySA :-/\n");
+		return;
+	}
+	m_vendor= "tinySA";
+	// Get model out of first line of info command response
+	m_model= ConverseSingle("info");
+	LogDebug("Model = %s\n",m_model.c_str());
+	m_fwVersion = version;
+	LogDebug("Version = %s\n",m_fwVersion.c_str());
+	//Add spectrum view channel
+	m_channels.push_back(
+		new SpectrumChannel(
+		this,
+		string("CH1"),
+		string("#ffff00"),
+		m_channels.size()));
+	// Get span information
+}
+
+TinySA::~TinySA()
+{
+}
+
+
+size_t TinySA::ConverseMultiple(const std::string commandString, std::vector<string> &readLines)
+{
+	stringstream ss(ConverseString(commandString));
+	string result;
+	string curLine;
+	bool firstLine = true;
+	size_t size = 0;
+    while (getline(ss, curLine)) 
+	{
+		if(firstLine)
+		{
+			//if(curLine.compare(commandString) != 0)
+			//	LogWarning("Unexpected response '%s' to command string '%s'.\n",curLine.c_str(),commandString.c_str());
+			firstLine = false;
+		}
+        else if (!curLine.empty()) 
+		{
+            readLines.push_back(curLine);
+			size++;
+        }
+    }
+	return size;
+}
+
+std::string TinySA::ConverseSingle(const std::string commandString)
+{
+	stringstream ss(ConverseString(commandString));
+	string result;
+	// Read first line (echo of command string)
+	getline(ss,result);
+	//if(result.compare(commandString) != 0)
+	//	LogWarning("Unexpected response '%s' to command string '%s'.\n",result.c_str(),commandString.c_str());
+	// Get second line as result
+	getline(ss,result);
+	return result;
+}
+
+std::string TinySA::ConverseString(const std::string commandString)
+{
+	string result = "";
+	// Lock guard
+	lock_guard<recursive_mutex> lock(m_transportMutex);
+	m_transport->SendCommand(commandString+"\r\n");
+	// Read untill we get  "ch>\r\n"
+	char tmp = ' ';
+	size_t bytesRead = 0;
+	while(true)
+	{	// Consume response until we find the end delimiter
+		if(!m_transport->ReadRawData(1,(unsigned char*)&tmp))
+			break;
+		result += tmp;
+		bytesRead++;
+		if(bytesRead > MAX_RESPONSE_SIZE)
+		{
+			LogError("Error while reading data from TinySA: response too long (%zu bytes).\n",bytesRead);
+			break;
+		}
+		if(result.size()>=TRAILER_STRING_LENGTH && (0 == result.compare (result.length() - TRAILER_STRING_LENGTH, TRAILER_STRING_LENGTH, TRAILER_STRING)))
+			break;
+	}
+	//LogDebug("Received: %s\n",result.c_str());
+	return result;
+}
+
+size_t TinySA::ConverseBinary(const std::string commandString, std::vector<uint8_t> &data)
+{
+	return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Accessors
+
+///@brief Return the constant driver name string "tektronix"
+string TinySA::GetDriverNameInternal()
+{
+	return "tiny-sa";
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device interface functions
+
+OscilloscopeChannel* TinySA::GetExternalTrigger()
+{
+	return NULL;
+}
+
+Oscilloscope::TriggerMode TinySA::PollTrigger()
+{
+	//Always report "triggered" so we can block on AcquireData() in ScopeThread
+	return TRIGGER_MODE_TRIGGERED;
+}
+
+void TinySA::FlushConfigCache()
+{
+	SCPISA::FlushConfigCache();
+	m_sampleDepthValid = false;
+}
+
+bool TinySA::AcquireData()
+{
+	//LogDebug("Acquiring data\n");
+
+/*	map<int, vector<WaveformBase*> > pending_waveforms;
+
+	lock_guard<recursive_mutex> lock(m_transport->GetMutex());
+
+			// Set source (before setting format)
+			m_transport->SendCommandImmediate(string("DAT:SOU ") + GetOscilloscopeChannel(i)->GetHwname() + "_SV_NORMAL");
+
+			//Select mode
+			if(firstSpectrum || retry) // set again on retry
+			{
+				m_transport->SendCommandImmediate("DAT:WID 8");					//double precision floating point data
+				m_transport->SendCommandImmediate("DAT:ENC SFPB");				//IEEE754 float
+				firstSpectrum = false;
+			}
+
+			//Ask for the waveform preamble
+			string preamble_str = m_transport->SendCommandImmediateWithReply("WFMO?", false);
+			mso56_preamble preamble;
+
+			//LogDebug("Channel %zu (%s)\n", nchan, m_channels[nchan]->GetHwname().c_str());
+			//LogIndenter li2;
+
+			//Process it
+			if (!ReadPreamble(preamble_str, preamble))
+				continue; // retry
+
+			m_channelOffsets[i] = -preamble.yoff;
+
+			//Read the data block
+			size_t msglen;
+			double* samples = (double*)m_transport->SendCommandImmediateWithRawBlockReply("CURV?", msglen);
+			if(samples == NULL)
+			{
+				LogWarning("Didn't get any samples (timeout?)\n");
+
+				ResynchronizeSCPI();
+
+				continue; // retry
+			}
+
+			size_t nsamples = msglen/8;
+
+			if (nsamples != (size_t)preamble.nr_pt)
+			{
+				LogWarning("Didn't get the right number of points\n");
+
+				ResynchronizeSCPI();
+
+				delete[] samples;
+
+				continue; // retry
+			}
+
+			//Set up the capture we're going to store our data into
+			//(no TDC data or fine timestamping available on Tektronix scopes?)
+			auto cap = new UniformAnalogWaveform;
+			cap->m_timescale = preamble.hzbase;
+			cap->m_triggerPhase = 0;
+			cap->m_startTimestamp = time(NULL);
+			double t = GetTime();
+			cap->m_startFemtoseconds = (t - floor(t)) * FS_PER_SECOND;
+			cap->Resize(nsamples);
+			cap->PrepareForCpuAccess();
+
+			//We get dBm from the instrument, so just have to convert double to single precision
+			//TODO: are other units possible here?
+			//int64_t ibase = preamble.hzoff / preamble.hzbase;
+			for(size_t j=0; j<nsamples; j++)
+				cap->m_samples[j] = preamble.ymult*samples[j] + preamble.yoff;
+
+			//Done, update the data
+			cap->MarkSamplesModifiedFromCpu();
+			pending_waveforms[nchan].push_back(cap);
+
+			//Done
+			delete[] samples;
+
+			//Throw out garbage at the end of the message (why is this needed?)
+			m_transport->ReadReply();
+
+			//Look for peaks
+			//TODO: make this configurable, for now 1 MHz spacing and up to 10 peaks
+			dynamic_cast<SpectrumChannel*>(m_channels[nchan])->FindPeaks(cap, 10, 1000000);
+
+	//Now that we have all of the pending waveforms, save them in sets across all channels
+	m_pendingWaveformsMutex.lock();
+	size_t num_pending = 1;	//TODO: segmented capture support
+	for(size_t i=0; i<num_pending; i++)
+	{
+		SequenceSet s;
+		for(size_t j=0; j<m_channels.size(); j++)
+		{
+			if(IsChannelEnabled(j))
+				s[GetOscilloscopeChannel(j)] = pending_waveforms[j][i];
+		}
+		m_pendingWaveforms.push_back(s);
+	}
+	m_pendingWaveformsMutex.unlock();
+
+	//Re-arm the trigger if not in one-shot mode
+	if(!m_triggerOneShot)
+	{
+		lock_guard<recursive_mutex> lock3(m_cacheMutex);
+		FlushChannelEnableStates();
+
+		m_transport->SendCommandImmediate("ACQ:STATE ON");
+		m_triggerArmed = true;
+	}
+*/
+	//LogDebug("Acquisition done\n");
+	return true;
+}
+
+
+void TinySA::Start()
+{
+	m_triggerArmed = true;
+	m_triggerOneShot = false;
+}
+
+void TinySA::StartSingleTrigger()
+{
+	m_triggerArmed = true;
+	m_triggerOneShot = true;
+}
+
+void TinySA::Stop()
+{
+	m_triggerArmed = false;
+	m_triggerOneShot = false;
+}
+
+void TinySA::ForceTrigger()
+{
+	m_triggerArmed = true;
+	m_triggerOneShot = true;
+}
+
+bool TinySA::IsTriggerArmed()
+{
+	return m_triggerArmed;
+}
+
+vector<uint64_t> TinySA::GetSampleDepthsNonInterleaved()
+{
+	vector<uint64_t> ret;
+	ret.push_back(51);
+	ret.push_back(101);
+	ret.push_back(145);
+	ret.push_back(290);
+	ret.push_back(500);
+	ret.push_back(1000);
+	ret.push_back(3000);
+	ret.push_back(10000);
+	ret.push_back(30000);
+	return ret;
+}
+
+uint64_t TinySA::GetSampleDepth()
+{
+	if(!m_sampleDepthValid)
+	{
+		m_sampleDepth = 0;
+		m_sampleDepthValid = true;
+	}
+	return m_sampleDepth;
+}
+
+void TinySA::SetSampleDepth(uint64_t depth)
+{
+}
+
+void TinySA::PullTrigger()
+{
+	//pulling not needed, we always have a valid trigger cached
+}
+
+void TinySA::PushTrigger()
+{
+	//do nothing
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Spectrum analyzer mode
+
+int64_t TinySA::GetResolutionBandwidth()
+{
+	return m_rbw;
+}
+
+void TinySA::SetResolutionBandwidth(int64_t rbw)
+{	
+	m_rbw = rbw;
+	m_rbwValid = true;
+	// TODO
+}
+
+void TinySA::SetSpan([[maybe_unused]] int64_t span)
+{	// TODO
+}
+
+int64_t TinySA::GetSpan()
+{	// TODO
+	return 0;
+}
+
+void TinySA::SetCenterFrequency([[maybe_unused]] size_t channel,[[maybe_unused]] int64_t freq)
+{	// TODO
+}
+
+int64_t TinySA::GetCenterFrequency([[maybe_unused]] size_t channel)
+{	// TODO
+	return 0;
+}

--- a/scopehal/TinySA.h
+++ b/scopehal/TinySA.h
@@ -118,7 +118,7 @@ protected:
 	inline static const std::string EOL_STRING = "\r\n";
 	inline static const size_t EOL_STRING_LENGTH = EOL_STRING.size();
 	static const size_t MAX_RESPONSE_SIZE = 100*1024;
-	inline static const double COMMUNICATION_TIMEOUT = 0.2; // 200 ms
+	inline static const double COMMUNICATION_TIMEOUT = 0.5; // 500ms
 
 public:
 	static std::string GetDriverNameInternal();

--- a/scopehal/TinySA.h
+++ b/scopehal/TinySA.h
@@ -62,8 +62,6 @@ public:
 
 	//Channel configuration
 
-	virtual void FlushConfigCache() override;
-
 	//Triggering
 	virtual OscilloscopeChannel* GetExternalTrigger() override;
 	virtual Oscilloscope::TriggerMode PollTrigger() override;
@@ -93,27 +91,51 @@ public:
 	virtual int64_t GetResolutionBandwidth() override;
 
 protected:
+	enum Model {
+		TINY_SA,
+		TINY_SA_ULTRA
+	};
+
 	// Make sure several request don't collide before we received the corresponding response
 	std::recursive_mutex m_transportMutex;
 
 	std::string ConverseSingle(const std::string commandString);
 	size_t ConverseMultiple(const std::string commandString, std::vector<std::string> &readLines);
 	std::string ConverseString(const std::string commandString);
-	size_t ConverseBinary(const std::string commandString, std::vector<uint8_t> &data);
+	size_t ConverseBinary(const std::string commandString, std::vector<uint8_t> &data, size_t length);
+	int64_t ConverseRbwValue(bool sendValue = false, int64_t value = 0);
+
+	static void RemoveCR(std::string &toClean)
+	{
+		toClean.erase( std::remove(toClean.begin(), toClean.end(), '\r'), toClean.end() );
+	}
 
 	//config cache
 	std::string GetChannelColor(size_t i);
 
+
 	bool m_triggerArmed;
 	bool m_triggerOneShot;
 
-	bool m_sampleDepthValid;
 	int64_t m_sampleDepth;
-	bool m_rbwValid;
 	int64_t m_rbw;
+	int64_t m_rbwMin;
+	int64_t m_rbwMax;
+
+	Model m_tinySAModel;
+	// Span control
+	int64_t m_sweepStart;
+	int64_t m_sweepStop;
+
+	int64_t m_freqMin;
+	int64_t m_freqMax;
+	// dbm offset to apply on values received from the device (model depedant)
+	int64_t m_modelDbmOffset;
 
 	inline static const std::string TRAILER_STRING = "ch> ";
 	inline static const size_t TRAILER_STRING_LENGTH = TRAILER_STRING.size();
+	inline static const std::string EOL_STRING = "\r\n";
+	inline static const size_t EOL_STRING_LENGTH = EOL_STRING.size();
 	static const size_t MAX_RESPONSE_SIZE = 100*1024;
 
 public:

--- a/scopehal/TinySA.h
+++ b/scopehal/TinySA.h
@@ -62,33 +62,20 @@ public:
 
 	//Channel configuration
 
-	//Triggering
-	virtual OscilloscopeChannel* GetExternalTrigger() override;
-	virtual Oscilloscope::TriggerMode PollTrigger() override;
+	//Data acquisition
 	virtual bool AcquireData() override;
-	virtual void Start() override;
-	virtual void StartSingleTrigger() override;
-	virtual void Stop() override;
-	virtual void ForceTrigger() override;
-	virtual bool IsTriggerArmed() override;
-	virtual void PushTrigger() override;
-	virtual void PullTrigger() override;
 
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Spectrum analyzer configuration
 
 	virtual std::vector<uint64_t> GetSampleDepthsNonInterleaved() override;
-	virtual uint64_t GetSampleDepth() override;
-	virtual void SetSampleDepth(uint64_t depth) override;
 	virtual void SetSpan(int64_t span) override;
 	virtual int64_t GetSpan() override;
 	virtual void SetCenterFrequency(size_t channel, int64_t freq) override;
 	virtual int64_t GetCenterFrequency(size_t channel) override;
 
-	//TODO: Sweep configuration ?
-	virtual void SetResolutionBandwidth(int64_t rbw);
-	virtual int64_t GetResolutionBandwidth() override;
+	virtual void SetResolutionBandwidth(int64_t rbw) override;
 
 protected:
 	enum Model {
@@ -111,15 +98,8 @@ protected:
 		toClean.erase( std::remove(toClean.begin(), toClean.end(), '\r'), toClean.end() );
 	}
 
-	//config cache
 	std::string GetChannelColor(size_t i);
 
-
-	bool m_triggerArmed;
-	bool m_triggerOneShot;
-
-	int64_t m_sampleDepth;
-	int64_t m_rbw;
 	int64_t m_rbwMin;
 	int64_t m_rbwMax;
 

--- a/scopehal/TinySA.h
+++ b/scopehal/TinySA.h
@@ -1,0 +1,124 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2024 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@author Frederic Borry
+	@brief Declaration of TinySA
+
+	@ingroup scopedrivers
+ */
+
+#ifndef TinySA_h
+#define TinySA_h
+
+/**
+	@brief Driver for TinySA and TinySA Ultra Spectrum Analizers
+	@ingroup scopedrivers
+
+	TinySA and TinySA Ultra are hobyist low-cost Spectrum Analizer designed by Erik Kaashoek: https://tinysa.org/
+	They can be connected to a PC via a USB COM port.
+
+ */
+class TinySA
+	: public virtual SCPISA
+{
+public:
+	TinySA(SCPITransport* transport);
+	virtual ~TinySA();
+
+	//not copyable or assignable
+	TinySA(const TinySA& rhs) =delete;
+	TinySA& operator=(const TinySA& rhs) =delete;
+
+
+public:
+
+	//Channel configuration
+
+	virtual void FlushConfigCache() override;
+
+	//Triggering
+	virtual OscilloscopeChannel* GetExternalTrigger() override;
+	virtual Oscilloscope::TriggerMode PollTrigger() override;
+	virtual bool AcquireData() override;
+	virtual void Start() override;
+	virtual void StartSingleTrigger() override;
+	virtual void Stop() override;
+	virtual void ForceTrigger() override;
+	virtual bool IsTriggerArmed() override;
+	virtual void PushTrigger() override;
+	virtual void PullTrigger() override;
+
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Spectrum analyzer configuration
+
+	virtual std::vector<uint64_t> GetSampleDepthsNonInterleaved() override;
+	virtual uint64_t GetSampleDepth() override;
+	virtual void SetSampleDepth(uint64_t depth) override;
+	virtual void SetSpan(int64_t span) override;
+	virtual int64_t GetSpan() override;
+	virtual void SetCenterFrequency(size_t channel, int64_t freq) override;
+	virtual int64_t GetCenterFrequency(size_t channel) override;
+
+	//TODO: Sweep configuration ?
+	virtual void SetResolutionBandwidth(int64_t rbw);
+	virtual int64_t GetResolutionBandwidth() override;
+
+protected:
+	// Make sure several request don't collide before we received the corresponding response
+	std::recursive_mutex m_transportMutex;
+
+	std::string ConverseSingle(const std::string commandString);
+	size_t ConverseMultiple(const std::string commandString, std::vector<std::string> &readLines);
+	std::string ConverseString(const std::string commandString);
+	size_t ConverseBinary(const std::string commandString, std::vector<uint8_t> &data);
+
+	//config cache
+	std::string GetChannelColor(size_t i);
+
+	bool m_triggerArmed;
+	bool m_triggerOneShot;
+
+	bool m_sampleDepthValid;
+	int64_t m_sampleDepth;
+	bool m_rbwValid;
+	int64_t m_rbw;
+
+	inline static const std::string TRAILER_STRING = "ch> ";
+	inline static const size_t TRAILER_STRING_LENGTH = TRAILER_STRING.size();
+	static const size_t MAX_RESPONSE_SIZE = 100*1024;
+
+public:
+	static std::string GetDriverNameInternal();
+	OSCILLOSCOPE_INITPROC(TinySA)
+};
+
+#endif

--- a/scopehal/TinySA.h
+++ b/scopehal/TinySA.h
@@ -104,6 +104,7 @@ protected:
 	std::string ConverseString(const std::string commandString);
 	size_t ConverseBinary(const std::string commandString, std::vector<uint8_t> &data, size_t length);
 	int64_t ConverseRbwValue(bool sendValue = false, int64_t value = 0);
+	bool ConverseSweep(int64_t &sweepStart, int64_t &sweepStop, bool setValue = false);
 
 	static void RemoveCR(std::string &toClean)
 	{

--- a/scopehal/TinySA.h
+++ b/scopehal/TinySA.h
@@ -137,6 +137,7 @@ protected:
 	inline static const std::string EOL_STRING = "\r\n";
 	inline static const size_t EOL_STRING_LENGTH = EOL_STRING.size();
 	static const size_t MAX_RESPONSE_SIZE = 100*1024;
+	inline static const double COMMUNICATION_TIMEOUT = 0.2; // 200 ms
 
 public:
 	static std::string GetDriverNameInternal();

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -57,6 +57,7 @@
 #include "TektronixOscilloscope.h"
 #include "TektronixHSIOscilloscope.h"
 #include "ThunderScopeOscilloscope.h"
+#include "TinySA.h"
 
 #include "AntikernelLabsTriggerCrossbar.h"
 #include "MultiLaneBERT.h"
@@ -239,6 +240,7 @@ void DriverStaticInit()
 	AddDriverClass(TektronixOscilloscope);
 	AddDriverClass(TektronixHSIOscilloscope);
 	AddDriverClass(ThunderScopeOscilloscope);
+	AddDriverClass(TinySA);
 #ifdef __linux
 	AddDriverClass(SocketCANAnalyzer);
 #endif

--- a/scopehal/scopehal.h
+++ b/scopehal/scopehal.h
@@ -159,6 +159,7 @@ extern size_t g_maxComputeGroupCount[3];
 #include "SCPIPowerSupply.h"
 #include "SCPIRFSignalGenerator.h"
 #include "SpectrometerDarkFrameChannel.h"
+#include "SCPISA.h"
 #include "SCPISDR.h"
 #include "SCPISpectrometer.h"
 #include "SCPIVNA.h"


### PR DESCRIPTION
Hi Andrew,

This one adds a driver for the tinySA and tinySA ULTRA Spectrum Analyzers.
As these devices use UART over USB to communicate, I also added download progress support to SCPIUARTTransport class.
I also created a SCPISA base class that can be derived for other specan only instrument drivers.
Here is what it looks like:
![ngscopeclient_sTUtLS0JIe](https://github.com/user-attachments/assets/09fb7691-dfca-473d-9f46-4e9a49a5f19d)
It goes with a compagnon PR for documentation.

Best,

Frederic.