### PR TITLE
Tektronix driver - Cached frequency parameters

### DIFF
--- a/scopehal/TektronixOscilloscope.h
+++ b/scopehal/TektronixOscilloscope.h
@@ -316,7 +316,7 @@ protected:
 	std::map<int, bool> m_channelsEnabled;
 
 	///@brief Cached map of <channel ID, center frequency>
-	std::map<int, int64_t> m_channelsCenterFrequency;
+	std::map<int, int64_t> m_channelCenterFrequencies;
 
 	///@brief True if m_triggerChannel is valid, false if out of sync
 	bool m_triggerChannelValid;

--- a/scopehal/TektronixOscilloscope.h
+++ b/scopehal/TektronixOscilloscope.h
@@ -315,6 +315,9 @@ protected:
 	///@brief Cached map of <channel ID, enable flag>
 	std::map<int, bool> m_channelsEnabled;
 
+	///@brief Cached map of <channel ID, center frequency>
+	std::map<int, int64_t> m_channelsCenterFrequency;
+
 	///@brief True if m_triggerChannel is valid, false if out of sync
 	bool m_triggerChannelValid;
 
@@ -338,6 +341,12 @@ protected:
 
 	///@brief Offset from start of wavefrom to trigger position
 	int64_t m_triggerOffset;
+
+	///@brief True if span is valid, false if out of sync
+	bool m_spanValid;
+
+	///@brief Span value for frequency control
+	int64_t m_span;
 
 	std::map<size_t, int64_t> m_channelDeskew;
 	std::map<size_t, ProbeType> m_probeTypes;


### PR DESCRIPTION
Hi Andrew,

To match the Specan fixes PR (https://github.com/ngscopeclient/scopehal-apps/pull/799), here is cache for frequency parameters on Tektronix driver, which was the only one not caching these values.
I could not test it since I don't have a Tek scope (I wish I did!;-), but hopefully I didn't break anything !...

Best,

Frederic.