### PR TITLE
Multimeter fixes

### DIFF
--- a/scopehal/LeCroyOscilloscope.cpp
+++ b/scopehal/LeCroyOscilloscope.cpp
@@ -86,6 +86,7 @@ LeCroyOscilloscope::LeCroyOscilloscope(SCPITransport* transport)
 	, m_interleavingValid(false)
 	, m_meterMode(Multimeter::DC_VOLTAGE)
 	, m_meterModeValid(false)
+	, m_dmmAutorangeValid(false)
 	, m_highDefinition(false)
 {
 	//standard initialization
@@ -1071,6 +1072,7 @@ void LeCroyOscilloscope::FlushConfigCache()
 	m_triggerOffsetValid = false;
 	m_interleavingValid = false;
 	m_meterModeValid = false;
+	m_dmmAutorangeValid = false;
 
 	//Clear cached display name of all channels
 	for(auto c : m_channels)
@@ -1891,14 +1893,23 @@ int LeCroyOscilloscope::GetMeterDigits()
 
 bool LeCroyOscilloscope::GetMeterAutoRange()
 {
+	if(m_dmmAutorangeValid)
+		return m_dmmAutorange;
+
 	auto str = m_transport->SendCommandQueuedWithReply("VBS? 'return = app.acquisition.DVM.AutoRange'");
 	int ret;
 	sscanf(str.c_str(), "%d", &ret);
-	return ret ? true : false;
+	m_dmmAutorange = (ret ? true : false);
+
+	m_dmmAutorangeValid = true;
+	return m_dmmAutorange;
 }
 
 void LeCroyOscilloscope::SetMeterAutoRange(bool enable)
 {
+	m_dmmAutorange = enable;
+	m_dmmAutorangeValid = true;
+
 	if(enable)
 		m_transport->SendCommandQueued("VBS 'app.acquisition.DVM.AutoRange = 1'");
 	else

--- a/scopehal/LeCroyOscilloscope.h
+++ b/scopehal/LeCroyOscilloscope.h
@@ -375,6 +375,8 @@ protected:
 	bool m_interleavingValid;
 	Multimeter::MeasurementTypes m_meterMode;
 	bool m_meterModeValid;
+	bool m_dmmAutorangeValid;
+	bool m_dmmAutorange;
 	std::map<size_t, bool> m_probeIsActive;
 
 	//True if we have >8 bit capture depth

--- a/scopehal/OwonXDMMultimeter.h
+++ b/scopehal/OwonXDMMultimeter.h
@@ -76,6 +76,8 @@ public:
 protected:
 	bool m_modeValid;
 	bool m_secmodeValid;
+	bool m_dmmAutorangeValid;
+	bool m_dmmAutorange;
 	MeasurementTypes m_mode;
 	MeasurementTypes m_secmode;
 

--- a/scopehal/RohdeSchwarzHMC8012Multimeter.cpp
+++ b/scopehal/RohdeSchwarzHMC8012Multimeter.cpp
@@ -41,6 +41,7 @@ RohdeSchwarzHMC8012Multimeter::RohdeSchwarzHMC8012Multimeter(SCPITransport* tran
 	, SCPIInstrument(transport)
 	, m_modeValid(false)
 	, m_secmodeValid(false)
+	, m_dmmAutorangeValid(false)
 {
 	//prefetch operating mode
 	GetMeterMode();
@@ -100,6 +101,9 @@ int RohdeSchwarzHMC8012Multimeter::GetMeterDigits()
 
 bool RohdeSchwarzHMC8012Multimeter::GetMeterAutoRange()
 {
+	if(m_dmmAutorangeValid)
+		return m_dmmAutorange;
+
 	string reply;
 
 	switch(m_mode)
@@ -122,19 +126,28 @@ bool RohdeSchwarzHMC8012Multimeter::GetMeterAutoRange()
 
 		//no autoranging in temperature mode
 		case TEMPERATURE:
+			m_dmmAutorangeValid = true;
+			m_dmmAutorange = false;
 			return false;
 
 		//TODO
 		default:
 			LogError("GetMeterAutoRange not implemented yet for modes other than DC_CURRENT\n");
+			m_dmmAutorangeValid = true;
+			m_dmmAutorange = false;
 			return false;
 	}
 
-	return (reply == "1");
+	m_dmmAutorange = (reply == "1");
+	m_dmmAutorangeValid = true;
+	return m_dmmAutorange;
 }
 
 void RohdeSchwarzHMC8012Multimeter::SetMeterAutoRange(bool enable)
 {
+	m_dmmAutorange = enable;
+	m_dmmAutorangeValid = true;
+
 	switch(m_mode)
 	{
 		case AC_RMS_AMPLITUDE:

--- a/scopehal/RohdeSchwarzHMC8012Multimeter.h
+++ b/scopehal/RohdeSchwarzHMC8012Multimeter.h
@@ -71,6 +71,8 @@ public:
 protected:
 	bool m_modeValid;
 	bool m_secmodeValid;
+	bool m_dmmAutorangeValid;
+	bool m_dmmAutorange;
 	MeasurementTypes m_mode;
 	MeasurementTypes m_secmode;
 

--- a/scopehal/Unit.cpp
+++ b/scopehal/Unit.cpp
@@ -586,6 +586,8 @@ void Unit::GetUnitSuffix(UnitType type, double num, double& scaleFactor, string&
  */
 string Unit::PrettyPrint(double value, int sigfigs, bool useDisplayLocale) const
 {
+	if(value >= std::numeric_limits<double>::max())
+		return UNIT_OVERLOAD_LABEL;
 	if(useDisplayLocale)
 		SetPrintingLocale();
 
@@ -961,6 +963,9 @@ string Unit::PrettyPrintRange(double pixelMin, double pixelMax, double rangeMin,
  */
 double Unit::ParseString(const string& str, bool useDisplayLocale)
 {
+	if(str == UNIT_OVERLOAD_LABEL)
+		return std::numeric_limits<double>::max();
+
 	if(useDisplayLocale)
 		SetPrintingLocale();
 

--- a/scopehal/Unit.h
+++ b/scopehal/Unit.h
@@ -46,6 +46,8 @@
 
 #endif
 
+#define UNIT_OVERLOAD_LABEL "Overload"
+
 /**
 	@brief A unit of measurement, plus conversion to pretty-printed output
 


### PR DESCRIPTION
Hi Andrew,

This PR goes along with Mutimeter rendering in StreamBrowserDialog.
It adds caching for autorange mode setting on existing DMM drivers.
It also adds a special handling of std::numeric_limits<double>::max() in Unit::PrettyPrint() method to display "Overload" message when DMM is overloaded.
Finally there are some fixes for Owon XDM driver.

Best,

Frederic.