### PR TITLE
Allow the "small number of waveforms" path to also use AVX512

### DIFF
--- a/scopehal/Oscilloscope.cpp
+++ b/scopehal/Oscilloscope.cpp
@@ -1290,6 +1290,11 @@ void Oscilloscope::Convert16BitSamples(float* pout, const int16_t* pin, float ga
 	else
 	{
 		#ifdef __x86_64__
+		if(g_hasAvx512F)
+		{
+			Convert16BitSamplesAVX512F(pout + off, pin + off, gain, offset, nsamp);
+		}
+
 		if(g_hasAvx2)
 		{
 			if(g_hasFMA)


### PR DESCRIPTION
AVX512 support was added to Oscilloscope::Convert16BitSamples, but only for the code branch `if(count > 1000000)`. Add AVX512 support to the `else` code branch too.