### PR TITLE
Fix Windows CI/build by removing no-longer-necessary link library

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -246,7 +246,6 @@ target_link_libraries(scopehal
 	Vulkan::Loader
 	Vulkan::Headers
 	glslang::glslang
-	glslang::SPIRV
 	glfw
 	${WIN_LIBS}
 	)


### PR DESCRIPTION
Newer versions of glslang do not ship this library separately, so we no longer need to link to it. Build works correctly on Windows and macOS.