### PR TITLE
Rigolredo basic functionality for MSO2000A

### DIFF
--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -116,11 +116,18 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 		break;
 		
 	case MSO2x_DS2x:
+	{
 		m_bandwidth = m_modelNumber % 1000 - nchans;
-		// TODO get the opts
-		
+		auto reply = Trim(m_transport->SendCommandQueuedWithReply(":SYST:OPT:VAL? MEMDepth\n"));
+		int opt_validity = 0;
+		sscanf(reply.c_str(), "%d", &opt_validity);
+		if (opt_validity >= 2)
+		{
+			m_opts.mso2.deep_memory = true;
+		}
+		// TODO get the other opts (advanced triggering, decoding, CAN analysis)
 		break;
-		
+	}
 	case MSO5:
 	{
 		// Hacky workaround since :SYST:OPT:STAT doesn't work properly on some scopes

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -96,14 +96,35 @@ public:
 	void ForceHDMode(bool mode);
 
 protected:
-	enum protocol_version
+	enum family
 	{
+		DS1x_OLD,
+		DS1x,
+		MSO2x_DS2x, // MSO2000A(-S) / DS2000A series
 		MSO5,	 //MSO5000 series
-		DS,
-		DS_OLD,
 		DHO,	//DHO800, DHO900, DHO1000 and DHO4000 series
 	};
-
+	
+	
+	typedef struct
+	{
+		bool advanced_trigger;
+		bool decoding;
+		bool CAN_analysis;
+		bool deep_memory;
+	} stOpts_MSO2xDS2x;
+	
+	typedef struct
+	{
+		bool bw200M;
+	} stOpts_MSO5;
+	
+	typedef union
+	{
+		stOpts_MSO2xDS2x mso2;
+		stOpts_MSO5 mso5;
+	} stOpts;
+	
 	OscilloscopeChannel* m_extTrigChannel;
 
 	//hardware analog channel count, independent of LA option etc
@@ -131,11 +152,12 @@ protected:
 
 	int m_modelNumber;
 	unsigned int m_bandwidth;
-	bool m_opt200M;
+	stOpts m_opts;
+	
 	uint64_t m_maxMdepth; /* Maximum Memory depth for DHO model s*/
 	uint64_t m_maxSrate;  /* Maximum Sample rate for DHO models */
 	bool m_lowSrate;	  /* True for DHO low sample rate models (DHO800/900) */
-	protocol_version m_protocol;
+	family m_family;
 
 	//True if we have >8 bit capture depth
 	bool m_highDefinition;


### PR DESCRIPTION
No attempt at logic analyser channels yet, but basic support for MSO2/DS2 family added. I think the other families should take the same code paths as before, but that's only verified by me having a bit of a think about it, since I don't have the other models to test against.

Really this is just a first pass to see if you're okay with the approach I'm taking.