### PR TITLE
Support for Sinilink PSUs

### DIFF
--- a/scopehal/CMakeLists.txt
+++ b/scopehal/CMakeLists.txt
@@ -192,6 +192,7 @@ set(SCOPEHAL_SOURCES
 	RohdeSchwarzHMC8012Multimeter.cpp
 	RohdeSchwarzHMC804xPowerSupply.cpp
 	RidenPowerSupply.cpp
+	SinilinkPowerSupply.cpp
 	KuaiquPowerSupply.cpp
 
 	StandardColors.cpp

--- a/scopehal/SinilinkPowerSupply.cpp
+++ b/scopehal/SinilinkPowerSupply.cpp
@@ -1,0 +1,174 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2024 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@brief Implementation of SinilinkPowerSupply
+	@ingroup psudrivers
+ */
+
+
+#include "scopehal.h"
+#include "SinilinkPowerSupply.h"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Construction / destruction
+
+/**
+	@brief Initialize the driver
+
+	@param transport	SCPITransport connected to the instrument
+ */
+
+
+
+SinilinkPowerSupply::SinilinkPowerSupply(SCPITransport* transport)
+	: SCPIDevice(transport, false), SCPIInstrument(transport, false), ModbusInstrument(transport)
+{
+	// Only supports one channel for Sinilink PSUs
+	m_channels.push_back(new PowerSupplyChannel("CH1", this, "#008000", 0));
+	m_vendor = "sinilink";
+	// Read model number
+	uint16_t modelNumber = ReadRegister(REGISTER_MODEL);
+	m_model = to_string(modelNumber/10) +"-" + to_string(modelNumber%10);
+	// Read serial number
+	uint16_t serialNumber = ReadRegister(REGISTER_SERIAL);
+	m_serial = to_string(serialNumber);
+	// Read firmware version number
+	float firmwareVersion = ((float)ReadRegister(REGISTER_FIRMWARE))/100;
+	m_fwVersion = to_string(firmwareVersion);
+	// Unlock remote control
+	WriteRegister(REGISTER_LOCK,0x00);
+}
+
+SinilinkPowerSupply::~SinilinkPowerSupply()
+{
+
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device info
+
+///@brief Return the constant driver name "SiniLink"
+string SinilinkPowerSupply::GetDriverNameInternal()
+{
+	return "SiniLink";
+}
+
+uint32_t SinilinkPowerSupply::GetInstrumentTypesForChannel([[maybe_unused]] size_t i) const
+{
+	return INST_PSU;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device capabilities
+
+bool SinilinkPowerSupply::SupportsIndividualOutputSwitching()
+{
+	return true;
+}
+
+bool SinilinkPowerSupply::SupportsVoltageCurrentControl(int chan)
+{
+	return (chan == 0);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Actual hardware interfacing
+
+bool SinilinkPowerSupply::IsPowerConstantCurrent(int chan)
+{
+	if(chan == 0)
+		return (ReadRegister(REGISTER_CVCC)==0x01);
+	else
+		return false;
+}
+
+double SinilinkPowerSupply::GetPowerVoltageActual(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(REGISTER_V_OUT))/100;
+}
+
+double SinilinkPowerSupply::GetPowerVoltageNominal(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(REGISTER_V_SET))/100;
+}
+
+double SinilinkPowerSupply::GetPowerCurrentActual(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(REGISTER_I_OUT))/1000;
+}
+
+double SinilinkPowerSupply::GetPowerCurrentNominal(int chan)
+{
+	if(chan != 0)
+		return 0;
+	return ((double)ReadRegister(REGISTER_I_SET))/1000;
+}
+
+bool SinilinkPowerSupply::GetPowerChannelActive(int chan)
+{
+	if(chan != 0)
+		return false;
+	return (ReadRegister(REGISTER_ON_OFF)==0x0001);
+}
+
+void SinilinkPowerSupply::SetPowerVoltage(int chan, double volts)
+{
+	if(chan != 0)
+		return;
+	WriteRegister(REGISTER_V_SET,(uint16_t)(volts*100));
+}
+
+void SinilinkPowerSupply::SetPowerCurrent(int chan, double amps)
+{
+	if(chan != 0)
+		return;
+	WriteRegister(REGISTER_I_SET,(uint16_t)(amps*1000));
+}
+
+void SinilinkPowerSupply::SetPowerChannelActive(int chan, bool on)
+{
+	if(chan != 0)
+		return;
+	WriteRegister(REGISTER_ON_OFF, (on ? 0x01 : 0x00));
+}

--- a/scopehal/SinilinkPowerSupply.h
+++ b/scopehal/SinilinkPowerSupply.h
@@ -1,0 +1,102 @@
+/***********************************************************************************************************************
+*                                                                                                                      *
+* libscopehal                                                                                                          *
+*                                                                                                                      *
+* Copyright (c) 2012-2024 Andrew D. Zonenberg and contributors                                                         *
+* All rights reserved.                                                                                                 *
+*                                                                                                                      *
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the     *
+* following conditions are met:                                                                                        *
+*                                                                                                                      *
+*    * Redistributions of source code must retain the above copyright notice, this list of conditions, and the         *
+*      following disclaimer.                                                                                           *
+*                                                                                                                      *
+*    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the       *
+*      following disclaimer in the documentation and/or other materials provided with the distribution.                *
+*                                                                                                                      *
+*    * Neither the name of the author nor the names of any contributors may be used to endorse or promote products     *
+*      derived from this software without specific prior written permission.                                           *
+*                                                                                                                      *
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED   *
+* TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL *
+* THE AUTHORS BE HELD LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES        *
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR       *
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT *
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+* POSSIBILITY OF SUCH DAMAGE.                                                                                          *
+*                                                                                                                      *
+***********************************************************************************************************************/
+
+/**
+	@file
+	@brief Declaration of SinilinkPowerSupply
+	@ingroup psudrivers
+ */
+
+#ifndef SinilinkPowerSupply_h
+#define SinilinkPowerSupply_h
+
+/**
+	@brief Implementation for Sinilink PSUs such as XY-S3580, XY6020L
+	@ingroup psudrivers
+ */
+class SinilinkPowerSupply
+	: public virtual SCPIPowerSupply
+	, public virtual ModbusInstrument
+{
+public:
+	SinilinkPowerSupply(SCPITransport* transport);
+	virtual ~SinilinkPowerSupply();
+
+	//Device information
+	virtual uint32_t GetInstrumentTypesForChannel(size_t i) const override;
+
+	//Device capabilities
+	virtual bool SupportsIndividualOutputSwitching() override;
+	virtual bool SupportsVoltageCurrentControl(int chan) override;
+
+	//Read sensors
+	virtual double GetPowerVoltageActual(int chan) override;	//actual voltage after current limiting
+	virtual double GetPowerVoltageNominal(int chan) override;	//set point
+	virtual double GetPowerCurrentActual(int chan) override;	//actual current drawn by the load
+	virtual double GetPowerCurrentNominal(int chan) override;	//current limit
+	virtual bool GetPowerChannelActive(int chan) override;
+
+	//Configuration
+	virtual void SetPowerVoltage(int chan, double volts) override;
+	virtual void SetPowerCurrent(int chan, double amps) override;
+	virtual void SetPowerChannelActive(int chan, bool on) override;
+	virtual bool IsPowerConstantCurrent(int chan) override;
+
+protected:
+
+	enum Registers : uint8_t
+	{
+		REGISTER_MODEL    = 0x16,
+		REGISTER_SERIAL   = 0x19,
+		REGISTER_FIRMWARE = 0x17,
+
+		REGISTER_TEMP_C = 0x0D,
+		REGISTER_TEMP_F = 0x0E,
+
+		REGISTER_V_SET = 0x00,
+		REGISTER_I_SET = 0x01,
+		REGISTER_V_OUT = 0x02,
+		REGISTER_I_OUT = 0x03,
+
+		REGISTER_WATT    = 0x04,
+		REGISTER_V_INPUT = 0x05,
+		REGISTER_LOCK    = 0x0F,
+		REGISTER_ERROR   = 0x10,
+		REGISTER_CVCC    = 0x11,
+
+		REGISTER_ON_OFF  = 0x12
+	};
+
+
+public:
+	static std::string GetDriverNameInternal();
+	POWER_INITPROC(SinilinkPowerSupply);
+};
+
+#endif

--- a/scopehal/scopehal.cpp
+++ b/scopehal/scopehal.cpp
@@ -79,6 +79,7 @@
 #include "RohdeSchwarzHMC804xPowerSupply.h"
 #include "SiglentPowerSupply.h"
 #include "RidenPowerSupply.h"
+#include "SinilinkPowerSupply.h"
 #include "KuaiquPowerSupply.h"
 
 #include "SiglentLoad.h"
@@ -276,6 +277,7 @@ void DriverStaticInit()
 	AddPowerSupplyDriverClass(HP662xAPowerSupply);
 	AddPowerSupplyDriverClass(AlientekPowerSupply);
 	AddPowerSupplyDriverClass(RidenPowerSupply);
+	AddPowerSupplyDriverClass(SinilinkPowerSupply);
 	AddPowerSupplyDriverClass(KuaiquPowerSupply);
 
 	AddRFSignalGeneratorDriverClass(SiglentVectorSignalGenerator);


### PR DESCRIPTION
Hi NGscope crew.
This PR adds support for Sinilink PSUs and is heavily based on the RidenPowerSupply Drivers but with changed modbus registers.

This has been tested with an XYS3580 and the registers were acquired from [tinkering4fun/XY6020L-Modbus](https://github.com/tinkering4fun/XY6020L-Modbus) so it's probably compatible with other Sinilink PSUs.
Love the project, Wilhelm.