### PR TITLE
SiglentFunctionGenerator: only update frequncy if actually changed

### DIFF
--- a/scopehal/SiglentFunctionGenerator.cpp
+++ b/scopehal/SiglentFunctionGenerator.cpp
@@ -341,6 +341,10 @@ float SiglentFunctionGenerator::GetFunctionChannelFrequency(int chan)
 
 void SiglentFunctionGenerator::SetFunctionChannelFrequency(int chan, float hz)
 {
+	if(m_cachedFrequencyValid[chan] && std::abs(m_cachedFrequency[chan] - hz) < 1e-6)
+	{
+		return;
+	}
 	m_transport->SendCommandQueued(m_channels[chan]->GetHwname() + ":BSWV FRQ," + to_string(hz));
 
 	m_cachedFrequency[chan] = hz;

--- a/scopehal/SiglentFunctionGenerator.h
+++ b/scopehal/SiglentFunctionGenerator.h
@@ -88,7 +88,7 @@ protected:
 
 	//Config cache
 	bool m_cachedFrequencyValid[2];
-	int64_t m_cachedFrequency[2];
+	float m_cachedFrequency[2];
 	bool m_cachedEnableStateValid[2];
 	bool m_cachedOutputEnable[2];
 	bool m_cachedAmplitudeValid[2];


### PR DESCRIPTION
Tested on  a Siglent SDG1032X 

Without this patch, every filter graph update sent a set frequency command to the device, which caused it to freeze if the filter graph was running too fast

Also changed the cached value to be a float