### PR TITLE
WIP: Rigol oscilloscope refactor

### DIFF
--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1860,16 +1860,13 @@ Oscilloscope::TriggerMode RigolOscilloscope::PollTrigger()
 
 	if(stat == "TD")
 	{
-		if (m_series == Series::MSO5000)
-			// MSO5000Z reports triggered right at the triggering moment,
-			// but that does not imply data availability (returning TRIGGER_MODE_TRIGGERED does).
-			// So we return TRIGGER_MODE_RUN to not indicate data availability
-			// and rely on the `STOP` to arrive afterwards.
-			// This can be easily caused by long sampling times (e.g.: 10 ksps and 100k mem. depth)
-			return TRIGGER_MODE_RUN;
-		else
-			// TODO: check if other families trigger TD state is also affected or not
-			return TRIGGER_MODE_TRIGGERED;
+		// MSO5000Z reports triggered right at the triggering moment,
+		// but that does not imply data availability (returning TRIGGER_MODE_TRIGGERED does).
+		// So we return TRIGGER_MODE_RUN to not indicate data availability
+		// and rely on the `STOP` to arrive afterwards.
+		// This can be easily caused by long sampling times (e.g.: 10 ksps and 100k mem. depth)
+		// DHO800 is also affected, so we mask the TD state for all
+		return TRIGGER_MODE_RUN;
 	}
 	else if(stat == "RUN")
 		return TRIGGER_MODE_RUN;

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2987,8 +2987,8 @@ void RigolOscilloscope::SetSampleDepth(uint64_t depth)
 			}
 			// memory depth is configurable only when scope is not stopped
 			{
-				string original_trigger_status = m_transport->SendCommandQueuedWithReply(":TRIG:STAT?");
 				lock_guard<recursive_mutex> lock(m_transport->GetMutex()); // this sequence may not be interrupted by others
+				string original_trigger_status = m_transport->SendCommandQueuedWithReply(":TRIG:STAT?");
 				m_transport->SendCommandQueued(":RUN");
 				m_transport->SendCommandQueued("ACQ:MDEP " + to_string(depth));
 				//TODO: whould we also use switch to accept only valid values?

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -3084,47 +3084,8 @@ void RigolOscilloscope::SetSampleDepth(uint64_t depth)
 		case Series::DHO4000:
 		case Series::DHO800:
 		case Series::DHO900:
-		{	// DHO models
-			switch(depth)
-			{
-				case 1000:
-					m_transport->SendCommandQueued("ACQ:MDEP 1k");
-					break;
-				case 10000:
-					m_transport->SendCommandQueued("ACQ:MDEP 10k");
-					break;
-				case 100000:
-					m_transport->SendCommandQueued("ACQ:MDEP 100k");
-					break;
-				case 1000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 1M");
-					break;
-				case 5000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 5M");
-					break;
-				case 10000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 10M");
-					break;
-				case 25000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 25M");
-					break;
-				case 50000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 50M");
-					break;
-				case 100000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 100M");
-					break;
-				case 250000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 250M");
-					break;
-				case 500000000:
-					m_transport->SendCommandQueued("ACQ:MDEP 500M");
-					break;
-				default:
-					LogError("Invalid memory depth %" PRIu64 "\n", depth);
-			}
+			m_transport->SendCommandQueued("ACQ:MDEP " + to_string(depth));
 			break;
-		}
 
 		case Series::MSODS1000Z:
 		{

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1195,6 +1195,7 @@ void RigolOscilloscope::EnableChannel(size_t i)
 	{
 		lock_guard<recursive_mutex> lock(m_cacheMutex);
 		m_channelsEnabled.erase(i);
+		m_srate.reset();
 	}
 	UpdateDynamicCapabilities();
 }
@@ -1235,6 +1236,7 @@ void RigolOscilloscope::DisableChannel(size_t i)
 	{
 		lock_guard<recursive_mutex> lock(m_cacheMutex);
 		m_channelsEnabled.erase(i);
+		m_srate.reset();
 	}
 	UpdateDynamicCapabilities();
 }

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -466,8 +466,7 @@ void RigolOscilloscope::AnalyzeDeviceCapabilities() {
 			if(m_bandwidth == 0) m_bandwidth = 70; // Fallback for DHO80x models
 
 			m_highDefinition = true;
-			// DHO800/900 (DHO800 also have 50M memory since firmware v00.01.03.00.04  2024/07/11)
-			m_maxMdepth = 50*1000*1000;
+			m_maxMdepth = 25*1000*1000;
 			m_maxSrate  = 1.25*1000*1000*1000;
 			m_lowSrate = true;
 
@@ -482,7 +481,6 @@ void RigolOscilloscope::AnalyzeDeviceCapabilities() {
 			m_bandwidth = m_modelNew.number % 100 / 10 * 125; // 914 -> 24 -> 2 -> 250
 
 			m_highDefinition = true;
-			// DHO800/900 (DHO800 also have 50M memory since firmware v00.01.03.00.04  2024/07/11)
 			m_maxMdepth = 50*1000*1000;
 			m_maxSrate  = 1.25*1000*1000*1000;
 			m_lowSrate = true;

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1785,33 +1785,35 @@ struct Ds1000zSrate {
 };
 
 static std::vector<Ds1000zSrate> ds1000zSampleRates {
-	{                20, 1                 }, // 12k
-	{                50, 1                 }, // 12k
-	{               100, 1                 }, // 12k
-	{               200, 1 | 2             }, // 12k 120k
-	{               500, 1 | 2             }, // 12k 120k
-	{              1000, 1 | 2             }, // 12k 120k
-	{              2000, 1 | 2 | 4         }, // 12k 120k 1M2
-	{              5000, 1 | 2 | 4         }, // 12k 120k 1M2
-	{         10 * 1000, 1 | 2 | 4         }, // 12k 120k 1M2
-	{         20 * 1000, 1 | 2 | 4         }, // 12k 120k 1M2 12M
-	{         40 * 1000,                 16}, //                  24M
-	{         50 * 1000, 1 | 2 | 4 | 8     }, // 12k 120k 1M2 12M
-	{        100 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{        200 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{        400 * 1000,                 16}, //                  24M
-	{        500 * 1000, 1 | 2 | 4 | 8     }, // 12k 120k 1M2 12M
-	{   1 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{   2 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{   4 * 1000 * 1000,                 16}, //                  24M
-	{   5 * 1000 * 1000, 1 | 2 | 4 | 8     }, // 12k 120k 1M2 12M
-	{  10 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{  25 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{  50 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{ 125 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{ 250 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{ 500 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M
-	{1000 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}  // 12k 120k 1M2 12M 24M
+	//          1 CH sr                          1CH mDepths                  2 CH sr  3/4 CH sr  display halt of memory?
+	{                20, 1                 }, // 12k                           10        5         N
+	{                50, 1                 }, // 12k                           25       12 !       N   this special case looks to be caused by integer representation of the samplerate
+	{               100, 1                 }, // 12k                           50       25         N
+	{               200, 1 | 2             }, // 12k 120k                     100       50         N
+	{               500, 1 | 2             }, // 12k 120k                     250      125         N
+	{              1000, 1 | 2             }, // 12k 120k                     500      250         N
+	{              2000, 1 | 2 | 4         }, // 12k 120k 1M2                  1k      500         N
+	{              5000, 1 | 2 | 4         }, // 12k 120k 1M2                  2k5      1k25       N
+	{         10 * 1000, 1 | 2 | 4         }, // 12k 120k 1M2                  5k       2k5        N
+	{         20 * 1000, 1 | 2 | 4         }, // 12k 120k 1M2 12M             10k       5k         N
+	{         40 * 1000,                 16}, //                  24M         20k       10k        N
+	{         50 * 1000, 1 | 2 | 4 | 8     }, // 12k 120k 1M2 12M             25k      12k5        N
+	{        100 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M         50k      25k         N
+	{        200 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M        100k      50k         N
+	{        400 * 1000,                 16}, //                  24M        200k     100k         N
+	{        500 * 1000, 1 | 2 | 4 | 8     }, // 12k 120k 1M2 12M            250k     125k         N
+	{   1 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M        500k     250k         N
+	{   2 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M          1M     500k         N
+	{   4 * 1000 * 1000,                 16}, //                  24M          2M       1M         N
+	{   5 * 1000 * 1000, 1 | 2 | 4 | 8     }, // 12k 120k 1M2 12M              2M5      1M25       N
+	{  10 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M          5M       2M5        N
+	// 10 Msps is magical threshold above which the regularity breaks
+	{  25 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M         10M !     5M !       Y
+	{  50 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M         25M      12M5        Y
+	{ 125 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M         50M !    25M !       Y
+	{ 250 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M        125M      50M !       Y
+	{ 500 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}, // 12k 120k 1M2 12M 24M        250M     125M         Y
+	{1000 * 1000 * 1000, 1 | 2 | 4 | 8 | 16}  // 12k 120k 1M2 12M 24M        500M     250M         Y
 };
 
 vector<uint64_t> RigolOscilloscope::GetSampleRatesNonInterleaved()
@@ -1828,7 +1830,19 @@ vector<uint64_t> RigolOscilloscope::GetSampleRatesNonInterleaved()
 			auto mdepth = GetSampleDepth();
 			for (const auto& rate : ds1000zSampleRates)
 				if (rate.supportsMdepth(mdepth, divisor))
-					rates.push_back(rate.m_value / divisor);
+				{
+					// 125M is never divided by 2
+					// 125M /2 -> 50M  /2 -> 25M
+					// 250M /2 -> 125M /2 -> 50M
+					if (rate.m_value == 125'000'000 and divisor != 1)
+						rates.push_back(100'000'000 / divisor);
+					else if (rate.m_value == 25'000'000 and divisor != 1)
+						rates.push_back(20'000'000 / divisor);
+					else if (rate.m_value == 250'000'000 and divisor == 4)
+						rates.push_back(200'000'000 / divisor);
+					else
+						rates.push_back(rate.m_value / divisor);
+				}
 			return rates;
 		}
 
@@ -2182,7 +2196,14 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 			//     Mdepth = Srate * wlength
 			//     Mdepth = Srate * Tscale * 12
 			//     Mdepth / (Srate * 12) =  * Tscale
-			m_transport->SendCommandQueued(string(":TIM:SCAL ") + to_string(sampletime / 12 / 2)); // not sure why we need that / 2
+			auto const divisor = GetChannelDivisor();
+			LogTrace("setting target samplerate %lu, divisor %zu\n", rate, divisor);
+			auto const timescale = [&]() -> float {
+				if (divisor != 4 and (rate / divisor) >= 25'000'000)
+					return sampletime / 12 / 2;
+				return sampletime / 12;
+			}();
+			m_transport->SendCommandQueued(string(":TIM:SCAL ") + to_string(timescale));
 			// Due to unknown reason, when we read SCAL right fter changing, we get the old value
 			// solution is to execute _any_ command with response (e.g. *IDN? works).
 			// Another requirement is that this read has to happen after the acquisition finishes which could take a long time on samplerates

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -165,6 +165,27 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 			break;
 	}
 
+	// Add AC line external trigger input
+	switch (m_series)
+	{
+		case Series::MSODS1000Z:
+		case Series::MSO5000:
+		case Series::DHO1000:
+		case Series::DHO4000:
+		case Series::DS1000:
+			m_aclTrigChannel = new OscilloscopeChannel(
+			this, "ACL", "#FF0000", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS), Stream::STREAM_TYPE_TRIGGER, m_channels.size());
+			m_channels.push_back(m_aclTrigChannel);
+			m_aclTrigChannel->SetDisplayName("ACLine");
+			m_aclTrigChannel->SetDefaultDisplayName();
+			break;
+			
+		case Series::DHO800:
+		case Series::DHO900:
+		case Series::UNKNOWN:
+			break;
+	}
+
 	//Configure acquisition modes
 	switch (m_series) {
 		case Series::DS1000:
@@ -951,6 +972,9 @@ bool RigolOscilloscope::IsChannelEnabled(size_t i)
 {
 	//ext trigger should never be displayed
 	if(m_extTrigChannel and i == m_extTrigChannel->GetIndex())
+		return false;
+
+	if(m_aclTrigChannel and i == m_aclTrigChannel->GetIndex())
 		return false;
 
 	{

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -931,12 +931,30 @@ vector<unsigned int> RigolOscilloscope::GetChannelBandwidthLimiters(size_t /*i*/
 			}
 			break;
 		
-		case Series::DS1000:
-		case Series::DS1000Z:
 		case Series::DHO800:
 		case Series::DHO900:
 		case Series::DHO1000:
 		case Series::DHO4000:
+			switch(m_bandwidth)
+			{
+
+				case 70:
+				case 100:
+				case 200:
+					// TODO: 20 MHZ BW limit is forced when scale is below 200 uV/div (DHO4000 user manual)
+					return {20, 0};
+				case 400:
+				case 800:
+					// DHO4404/DHO480420 MHz, 250 MHz
+					// TODO: 250 MHZ BW limit is forced when scale is below 500 uV/div (DHO4000 user manual)
+					return {20, 250, 0};
+				default:
+					LogError("Invalid model bandwidth\n");
+			}
+			break;
+
+		case Series::DS1000:
+		case Series::DS1000Z:
 			return {20, 0};
 		
 		case Series::UNKNOWN:

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1217,9 +1217,11 @@ bool RigolOscilloscope::AcquireData()
 			// manual specifies 250k as a maximum for bytes output
 			// maxpoints = 250 * 1000;
 
-			// on my DS1054Z FW ... this larger chunk also works well and
-			// we get around ~20% speed-up when downloading a lot of data
-			maxpoints = 1024  * 1024;
+			// During experiments with my DS1054Z FW 00.04.05.SP2,
+			// 250kB limits applies when all channels are enabled.
+			// It is possible to use larger chunks with less channels.
+			// With single channel and 1 MB block, around ~20% speed-up is observable.
+			maxpoints = 1000 * 1000 / GetChannelDivisor();
 			break;
 		case Series::MSO5000:
 			maxpoints = GetSampleDepth();	 //You can use 250E6 points too, but it is very slow

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -217,46 +217,45 @@ void RigolOscilloscope::DecodeDeviceSeries()
 		m_modelNew.suffix.assign(cursor, m_model.end());
 
 		// decode into device family
+		if(m_modelNew.prefix == "DS" or m_modelNew.prefix == "MSO")
 		{
 			switch(m_modelNew.number / 1000)
 			{
 				case 1:
-					if(strcmp(m_modelNew.prefix.c_str(), "DS") != 0)
-						break;
-					if(m_modelNew.suffix.size() < 1)
-						break;
-					if(m_modelNew.suffix[0] == 'D' || m_modelNew.suffix[0] == 'E')
-						return Series::DS1000;
-					else if(m_modelNew.suffix[0] == 'Z')
-						return Series::MSODS1000Z;
+						if(m_modelNew.suffix.size() < 1)
+							break;
+						if(m_modelNew.suffix[0] == 'D' || m_modelNew.suffix[0] == 'E')
+							return Series::DS1000;
+						else if(m_modelNew.suffix[0] == 'Z')
+							return Series::MSODS1000Z;
 					break;
-				
-				// case 2:
-				// 	if(strcmp(m_modelNew.prefix.c_str(), "DS") == 0 || strcmp(m_modelNew.prefix.c_str(), "MSO") == 0)
-				// 		return Series::MSODS2000;
-				// 	break;
-				
-				case 5:
-					if(strcmp(m_modelNew.prefix.c_str(), "MSO") == 0)
-						return Series::MSO5000;
-					break;
-				
-				// case 7:
-				// 	if(strcmp(m_modelNew.prefix.c_str(), "DS") == 0 || strcmp(m_modelNew.prefix.c_str(), "MSO") == 0)
-				// 		return Series::MSODS7000;
-				// 	break;
-				
-				// case 8:
-				// 	if(strcmp(m_modelNew.prefix.c_str(), "MSO") == 0)
-				// 		return Series::MSO8000;
-				// 	break;
-				
-				default:
-					break;
+				case 5: return Series::MSO5000;
+				default: break;
 			}
-			LogError("model %s was not recognized\n", m_model.c_str());
-			return Series::UNKNOWN;
 		}
+		else if (m_modelNew.prefix == "DHO")
+		{
+			if (m_modelNew.number < 1000)
+			{
+				switch (m_modelNew.number / 100)
+				{
+					case 8: return Series::DHO800;
+					case 9: return Series::DHO900;
+					default: break;
+				}
+			}
+			else
+			{
+				switch (m_modelNew.number / 1000)
+				{
+					case 1: return Series::DHO1000;
+					case 4: return Series::DHO4000;
+					default: break;
+				}
+			}
+		}
+		LogError("model %s was not recognized\n", m_model.c_str());
+			return Series::UNKNOWN;
 	}();
 }
 

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2196,6 +2196,16 @@ int64_t RigolOscilloscope::GetTriggerOffset()
 	return m_triggerOffset;	
 }
 
+bool RigolOscilloscope::HasInterleavingControls()
+{
+	return false;
+}
+
+bool RigolOscilloscope::CanInterleave()
+{
+	return false;
+}
+
 bool RigolOscilloscope::IsInterleaving()
 {
 	return false;

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -925,9 +925,9 @@ float RigolOscilloscope::GetDigitalThreshold(size_t channel)
 	// pods index values start at 1
 	auto level = [&]() -> double {
 		auto const level_str = m_transport->SendCommandQueuedWithReply(string(":LA:POD") + to_string(bankIdx + 1) + ":THR?");
-		auto const level = parseDouble(level_str);
-		if (level)
-			return *level;
+		auto const level_opt = parseDouble(level_str);
+		if (level_opt)
+			return *level_opt;
 		LogError("could not parse channel %s threshold from %s\n", GetChannel(channel)->GetDisplayName().c_str(), level_str.c_str());
 		return 0;
 	}();
@@ -3023,9 +3023,9 @@ uint64_t RigolOscilloscope::GetSampleDepth()
 			// it may fail in the first loop, but whould get valid value in the second
 			// this way we avoid recursion
 			auto const depth_str = m_transport->SendCommandQueuedWithReply(":ACQ:MDEP?");
-			auto const depth = parseDouble(depth_str);
-			if (depth)
-				return *depth;
+			auto const depth_opt = parseDouble(depth_str);
+			if (depth_opt)
+				return *depth_opt;
 			LogError("could not parse sampled depth from %s. Falling back to lowest one\n", depth_str.c_str());
 			auto depths = GetSampleDepthsNonInterleaved();
 			if (depths.empty())

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1998,7 +1998,8 @@ bool RigolOscilloscope::AcquireData()
 					continue;
 				}
 
-				maxpoints = preamble->npoints;
+				if (maxpoints == 0)
+					maxpoints = preamble->npoints;
 
 				if(preamble->sec_per_sample == 0)
 				{	// Sometimes the scope might return a null value for xincrement => ignore waveform to prenvent an Arithmetic exception in WaveformArea::RasterizeAnalogOrDigitalWaveform 

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -117,7 +117,7 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 			m_transport->SendCommandQueued(":WAV:POIN:MODE RAW");
 			break;
 		
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 		case Series::DHO1000:
 		case Series::DHO4000:
@@ -142,13 +142,13 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 				m_transport->SendCommandQueued(":" + m_channels[i]->GetHwname() + ":VERN ON");
 			break;
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::UNKNOWN:
 			break;
 	}
 
 	switch (m_series) {
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 		case Series::DHO1000:
 		case Series::DHO4000:
@@ -241,7 +241,7 @@ void RigolOscilloscope::DecodeDeviceSeries()
 					if(m_modelNew.suffix[0] == 'D' || m_modelNew.suffix[0] == 'E')
 						return Series::DS1000;
 					else if(m_modelNew.suffix[0] == 'Z')
-						return Series::DS1000Z;
+						return Series::MSODS1000Z;
 					break;
 				
 				// case 2:
@@ -286,7 +286,7 @@ void RigolOscilloscope::AnalyzeDeviceCapabilities() {
 			m_bandwidth = m_modelNew.number % 1000 - m_analogChannelCount;
 			break;
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		{
 			m_analogChannelCount = m_modelNew.number % 10;
 			m_bandwidth = m_modelNew.number % 1000 - m_analogChannelCount;
@@ -564,7 +564,7 @@ void RigolOscilloscope::UpdateDynamicCapabilities() {
 			return;
 		}
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		{
 			// For the analog channel:
 			// ― 1 CH:   12000|120000|1200000|12000000|24000000
@@ -955,7 +955,7 @@ vector<unsigned int> RigolOscilloscope::GetChannelBandwidthLimiters(size_t /*i*/
 			break;
 
 		case Series::DS1000:
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 			return {20, 0};
 		
 		case Series::UNKNOWN:
@@ -1037,7 +1037,7 @@ float RigolOscilloscope::GetChannelVoltageRange(size_t i, size_t /*stream*/)
 
 	string reply;
 	switch (m_series) {
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 			reply = Trim(m_transport->SendCommandQueuedWithReply(":" + m_channels[i]->GetHwname() + ":RANGE?"));
 			break;
 
@@ -1062,7 +1062,7 @@ float RigolOscilloscope::GetChannelVoltageRange(size_t i, size_t /*stream*/)
 		lock_guard<recursive_mutex> lock(m_cacheMutex);
 
 		switch (m_series) {
-			case Series::DS1000Z:
+			case Series::MSODS1000Z:
 				return m_channelVoltageRanges[i] = range;
 
 			case Series::DS1000:
@@ -1090,7 +1090,7 @@ void RigolOscilloscope::SetChannelVoltageRange(size_t i, size_t /*stream*/, floa
 	}
 
 	switch (m_series) {
-			case Series::DS1000Z:
+			case Series::MSODS1000Z:
 				m_transport->SendCommandQueued(":" + m_channels[i]->GetHwname() + ":RANGE " + to_string(range));
 				return;
 			
@@ -1154,7 +1154,7 @@ Oscilloscope::TriggerMode RigolOscilloscope::PollTrigger()
 
 	LogTrace("m_triggerArmed %d, m_triggerWasLive %d\n", m_triggerArmed, m_triggerWasLive);
 
-	if (m_series == Series::DS1000Z) {
+	if (m_series == Series::MSODS1000Z) {
 		// DS1000Z report trigger status in unreliable way.
 		// When triggered, it reports STOP for some time.
 		// Then it goes though RUN->WAIT->TRIG and ends up in STOP,
@@ -1273,7 +1273,7 @@ bool RigolOscilloscope::AcquireData()
 		case Series::DS1000:
 			maxpoints = 8192; // FIXME
 			break;
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 			// manual specifies 250k as a maximum for bytes output
 			// maxpoints = 250 * 1000;
 
@@ -1333,7 +1333,7 @@ bool RigolOscilloscope::AcquireData()
 				break;
 			}
 
-			case Series::DS1000Z:
+			case Series::MSODS1000Z:
 			case Series::MSO5000:
 			case Series::DHO1000:
 			case Series::DHO4000:
@@ -1395,7 +1395,7 @@ bool RigolOscilloscope::AcquireData()
 					m_transport->SendCommandQueued(string(":WAV:DATA? ") + m_channels[channelIdx]->GetHwname());
 					break;
 				
-				case Series::DS1000Z:
+				case Series::MSODS1000Z:
 				{
 					// specify block sample range
 					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint+1));	//ONE based indexing WTF
@@ -1583,7 +1583,7 @@ bool RigolOscilloscope::AcquireData()
 				m_transport->SendCommandQueued(":RUN");
 				break;
 
-			case Series::DS1000Z:
+			case Series::MSODS1000Z:
 			case Series::MSO5000:
 			case Series::DHO1000:
 			case Series::DHO4000:
@@ -1631,7 +1631,7 @@ void RigolOscilloscope::StartPre()
 			break;
 
 		case Series::DS1000:
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 		case Series::UNKNOWN:
 			break;
@@ -1668,7 +1668,7 @@ void RigolOscilloscope::Start()
 			m_transport->SendCommandQueued(":RUN");
 			break;
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 			m_transport->SendCommandQueued(":SING");
 			m_transport->SendCommandQueued("*WAI");
@@ -1713,7 +1713,7 @@ void RigolOscilloscope::StartSingleTrigger()
 			m_transport->SendCommandQueued(":RUN");
 			break;
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 		case Series::DHO1000:
 		case Series::DHO4000:
@@ -1746,7 +1746,7 @@ void RigolOscilloscope::ForceTrigger()
 	StartPre();
 	switch (m_series)
 	{
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 		case Series::DHO1000:
 		case Series::DHO4000:
@@ -1884,7 +1884,7 @@ vector<uint64_t> RigolOscilloscope::GetSampleRatesNonInterleaved()
 	//FIXME
 	switch (m_series)
 	{
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		{
 			vector<uint64_t> rates {};
 			auto divisor = GetChannelDivisor();
@@ -1988,7 +1988,7 @@ set<Oscilloscope::InterleaveConflict> RigolOscilloscope::GetInterleaveConflicts(
 			return {};
 		case Series::UNKNOWN:
 		case Series::DS1000:
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 			break;
 	}
@@ -2015,7 +2015,7 @@ vector<uint64_t> RigolOscilloscope::GetSampleDepthsInterleaved()
 			return GetSampleDepthsNonInterleaved();
 		
 		case Series::DS1000:
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 		case Series::UNKNOWN:
 			break;
@@ -2177,7 +2177,7 @@ void RigolOscilloscope::SetSampleDepth(uint64_t depth)
 			break;
 		}
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		{
 			if (depth == 24'000'000 and not m_opt24M) {
 				LogError("This DS1000Z device does not have 24M option installed\n");
@@ -2246,7 +2246,7 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 			break;
 		}
 
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		{
 			// The following equation describes the relationship among memory depth, sample rate, and waveform length:
 			//     Memory Depth = Sample Rate x Waveform Length
@@ -2485,7 +2485,7 @@ void RigolOscilloscope::ForceHDMode(bool mode)
 
 		case Series::UNKNOWN:
 		case Series::DS1000:
-		case Series::DS1000Z:
+		case Series::MSODS1000Z:
 		case Series::MSO5000:
 			//TODO: report/log invalidity of this
 			break;

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -60,6 +60,15 @@ static auto parseDouble(string const &input, const string &fmt = "%lf", double c
 	return parseNumeric<double>(input, fmt, fallback_value);
 }
 
+//TODO: this would make sens to move to some utility library
+template<typename T>
+struct CallOnEOC {
+	T onExit;
+	CallOnEOC(T onExit_) : onExit(onExit_) {}
+	~CallOnEOC() {
+		onExit();
+	}
+};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Construction / destruction

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -145,11 +145,25 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 		}
 	}
 
-	//Add the external trigger input
-	m_extTrigChannel = new OscilloscopeChannel(
-		this, "EX", "", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS), Stream::STREAM_TYPE_TRIGGER, m_channels.size());
-	m_channels.push_back(m_extTrigChannel);
-	m_extTrigChannel->SetDefaultDisplayName();
+	// Add the external trigger input
+	switch (m_series)
+	{
+		case Series::DS1000:
+		case Series::MSODS1000Z:
+		case Series::DHO1000:
+		case Series::DHO4000:
+		case Series::DHO800:
+		case Series::DHO900:
+			m_extTrigChannel = new OscilloscopeChannel(
+				this, "External", "#FFFFFF", Unit(Unit::UNIT_FS), Unit(Unit::UNIT_VOLTS), Stream::STREAM_TYPE_TRIGGER, m_channels.size());
+			m_channels.push_back(m_extTrigChannel);
+			m_extTrigChannel->SetDefaultDisplayName();
+			break;
+
+		case Series::MSO5000:
+		case Series::UNKNOWN:
+			break;
+	}
 
 	//Configure acquisition modes
 	switch (m_series) {
@@ -936,7 +950,7 @@ std::size_t RigolOscilloscope::IdxToDigitalBankIdx(std::size_t i)
 bool RigolOscilloscope::IsChannelEnabled(size_t i)
 {
 	//ext trigger should never be displayed
-	if(i == m_extTrigChannel->GetIndex())
+	if(m_extTrigChannel and i == m_extTrigChannel->GetIndex())
 		return false;
 
 	{

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -130,22 +130,9 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 		case Series::UNKNOWN:
 			break;
 	}
-
-	switch (m_series) {
-		case Series::DS1000:
-		case Series::MSO5000:
-		case Series::DHO1000:
-		case Series::DHO4000:
-		case Series::DHO800:
-		case Series::DHO900:
-			for(size_t i = 0; i < m_analogChannelCount; i++)
-				m_transport->SendCommandQueued(":" + m_channels[i]->GetHwname() + ":VERN ON");
-			break;
-
-		case Series::MSODS1000Z:
-		case Series::UNKNOWN:
-			break;
-	}
+	
+	for(size_t i = 0; i < m_analogChannelCount; i++)
+		m_transport->SendCommandQueued(":" + m_channels[i]->GetHwname() + ":VERN ON");
 
 	switch (m_series) {
 		case Series::MSODS1000Z:

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1587,7 +1587,7 @@ void RigolOscilloscope::SetChannelBandwidthLimit(size_t i, unsigned int limit_mh
 		return 0;
 	}();
 
-	// `new_limit` now holds value of limit suported by the device or 0 in case of full BW
+	// `new_limit` now holds value of limit supported by the device or 0 in case of full BW
 
 	if (new_limit > 0)
 		m_transport->SendCommandQueued(m_channels[i]->GetHwname() + ":BWL " + to_string(new_limit) + "M");
@@ -2954,7 +2954,7 @@ uint64_t RigolOscilloscope::GetSampleRate()
 		if(m_srate.has_value())
 			return *m_srate;
 	
-		LogTrace("smaplerate updating\n");
+		LogTrace("samplerate updating\n");
 	}
 	// m_transport->SendCommandQueued("*WAI");
 
@@ -2966,7 +2966,7 @@ uint64_t RigolOscilloscope::GetSampleRate()
 	{
 		lock_guard<recursive_mutex> lock(m_cacheMutex);
 		m_srate = (uint64_t)rate;
-		LogTrace("smaplerate updated, m_srate %" PRIu64 "\n", *m_srate);
+		LogTrace("samplerate updated, m_srate %" PRIu64 "\n", *m_srate);
 		return rate;
 	}
 }
@@ -3091,7 +3091,7 @@ void RigolOscilloscope::SetSampleDepth(uint64_t depth)
 					m_transport->SendCommandQueued("ACQ:MDEP 500M");
 					break;
 				default:
-					LogError("Invalid memory depth for channel: %" PRIu64 "\n", depth);
+					LogError("Invalid memory depth %" PRIu64 "\n", depth);
 			}
 			break;
 		}

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -58,10 +58,10 @@ static auto parseDouble(string const &input, const string &fmt = "%lf")
 	return parseNumeric<double>(input, fmt);
 }
 
-static auto parseU64(string const &input, const string &fmt = "%" PRIu64)
-{
-	return parseNumeric<uint64_t>(input, fmt);
-}
+// static auto parseU64(string const &input, const string &fmt = "%" PRIu64)
+// {
+// 	return parseNumeric<uint64_t>(input, fmt);
+// }
 
 //TODO: this would make sens to move to some utility library
 template<typename T>
@@ -2974,7 +2974,7 @@ uint64_t RigolOscilloscope::GetSampleDepth()
 			// it may fail in the first loop, but whould get valid value in the second
 			// this way we avoid recursion
 			auto const depth_str = m_transport->SendCommandQueuedWithReply(":ACQ:MDEP?");
-			auto const depth = parseU64(depth_str);
+			auto const depth = parseDouble(depth_str);
 			if (depth)
 				return *depth;
 			LogError("could not parse sampled depth from %s. Falling back to lowest one\n", depth_str.c_str());

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1815,7 +1815,18 @@ Oscilloscope::TriggerMode RigolOscilloscope::PollTrigger()
 		m_triggerWasLive = true;
 
 	if(stat == "TD")
-		return TRIGGER_MODE_TRIGGERED;
+	{
+		if (m_series == Series::MSO5000)
+			// MSO5000Z reports triggered right at the triggering moment,
+			// but that does not imply data availability (returning TRIGGER_MODE_TRIGGERED does).
+			// So we return TRIGGER_MODE_RUN to not indicate data availability
+			// and rely on the `STOP` to arrive afterwards.
+			// This can be easily caused by long sampling times (e.g.: 10 ksps and 100k mem. depth)
+			return TRIGGER_MODE_RUN;
+		else
+			// TODO: check if other families trigger TD state is also affected or not
+			return TRIGGER_MODE_TRIGGERED;
+	}
 	else if(stat == "RUN")
 		return TRIGGER_MODE_RUN;
 	else if(stat == "WAIT")

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1150,15 +1150,14 @@ void RigolOscilloscope::EnableChannel(size_t i)
 		m_transport->SendCommandQueued(":" + m_channels[i]->GetHwname() + ":DISP ON");
 		switch (m_series)
 		{
-			case Series::MSODS1000Z:
-				// impact of enabling analog channel takes effect (change of mem depth,...) only in RUN state
-				m_transport->SendCommandQueued(":SING");
-				m_transport->SendCommandQueued(":TFOR");
+			// this is a quirk that changes to take effect immediately
+			case Series::MSODS1000Z: // applies the configuration
+			case Series::MSO5000: // ensures the srate readout reads correct value
+				SetSampleDepth(GetSampleDepth());
 				break;
-			//TODO: check of other scopes require this too
+				//TODO: check of other scopes require this too
 			case Series::UNKNOWN:
 			case Series::DS1000:
-			case Series::MSO5000:
 			case Series::DHO1000:
 			case Series::DHO4000:
 			case Series::DHO800:

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -3139,6 +3139,20 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 	{
 		lock_guard<recursive_mutex> lock(m_cacheMutex);
 		m_mdepth.reset();
+
+		bool requestedValueisValid {};
+		auto rates = GetSampleRatesNonInterleaved();
+		for (auto const& depth : rates)
+			if (depth == rate)
+			{
+				requestedValueisValid = true;
+				break;
+			}
+		if (not requestedValueisValid)
+		{
+			LogWarning("requested sample rate %" PRIu64 " is not any of %zd of suported by this device\n", rate, rates.size());
+			return;
+		}
 	}
 	double sampletime = GetSampleDepth() / (double)rate;
 	// locally cache current value before we change the timebase,

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -48,6 +48,19 @@
 
 using namespace std;
 
+template<typename T>
+static T parseNumeric(string const &input, const string &fmt, T const &fallback_value = {}) {
+	T output {fallback_value};
+	sscanf(input.c_str(), fmt.c_str(), &output);
+	return output;
+}
+
+static auto parseDouble(string const &input, const string &fmt = "%lf", double const &fallback_value = numeric_limits<double>::quiet_NaN())
+{
+	return parseNumeric<double>(input, fmt, fallback_value);
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Construction / destruction
 

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -606,7 +606,7 @@ void RigolOscilloscope::UpdateDynamicCapabilities() {
 			// ― 2 CH:    6000| 60000| 600000| 6000000|12000000
 			// ― 3/4 CH:  3000| 30000| 300000| 3000000| 6000000
 			// -> 1 CH values appropriately divided
-			auto divisor = GetChannelDivisor();
+			auto divisor = GetMsods1000ZChannelDivisor();
 			vector<std::uint64_t> depths;
 			for (auto &depth : ds1000zSampleDepths)
 			{
@@ -628,7 +628,7 @@ void RigolOscilloscope::UpdateDynamicCapabilities() {
 	}
 }
 
-std::size_t RigolOscilloscope::GetChannelDivisor() {
+std::size_t RigolOscilloscope::GetMsods1000ZChannelDivisor() {
 	auto divisor = GetEnabledAnalogChannelCount();
 
 	// MSO1000Z:
@@ -1829,7 +1829,7 @@ bool RigolOscilloscope::AcquireData()
 			// 250kB limits applies when all channels are enabled.
 			// It is possible to use larger chunks with less channels.
 			// With single channel and 1 MB block, around ~20% speed-up is observable.
-			maxpoints = 1000 * 1000 / GetChannelDivisor();
+			maxpoints = 1000 * 1000 / GetMsods1000ZChannelDivisor();
 			break;
 		case Series::MSO5000:
 			maxpoints = GetSampleDepth();	 //You can use 250E6 points too, but it is very slow
@@ -2691,7 +2691,7 @@ vector<uint64_t> RigolOscilloscope::GetSampleRatesNonInterleaved()
 		case Series::MSODS1000Z:
 		{
 			vector<uint64_t> rates {};
-			auto divisor = GetChannelDivisor();
+			auto divisor = GetMsods1000ZChannelDivisor();
 			auto mdepth = GetSampleDepth();
 			for (const auto& rate : ds1000zSampleRates)
 				if (rate.supportsMdepth(mdepth, divisor))
@@ -3062,7 +3062,7 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 			//     Mdepth = Srate * wlength
 			//     Mdepth = Srate * Tscale * 12
 			//     Mdepth / (Srate * 12) =  * Tscale
-			auto const divisor = GetChannelDivisor();
+			auto const divisor = GetMsods1000ZChannelDivisor();
 			LogTrace("setting target samplerate %lu, divisor %zu\n", rate, divisor);
 			auto const timescale = [&]() -> float {
 				if (divisor != 4 and (rate / divisor) >= 25'000'000)

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2066,42 +2066,18 @@ bool RigolOscilloscope::AcquireData()
 				case Series::DS1000:
 					m_transport->SendCommandQueued(string(":WAV:DATA? ") + m_channels[channelIdx]->GetHwname());
 					break;
-				
+					
 				case Series::MSODS1000Z:
-				{
-					// specify block sample range
-					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint+1));	//ONE based indexing WTF
-					m_transport->SendCommandQueued(string("WAV:STOP ") + to_string(min(npoint + maxpoints, npoints)));	//Here it is zero based, so it gets from 1-1000
-					// m_transport->SendCommandQueued("*WAI"); // looks unnecessary
-
-					//Ask for the data block
-					m_transport->SendCommandQueued("WAV:DATA?");
-				} break;
-
-					
 				case Series::MSO5000:
-					//Ask for the data block
-					m_transport->SendCommandQueued("*WAI");
-					m_transport->SendCommandQueued("WAV:DATA?");
-					break;
-					
 				case Series::DHO1000:
 				case Series::DHO4000:
 				case Series::DHO800:
 				case Series::DHO900:
-				{
-					//Ask for the data
-					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint + 1));	//ONE based indexing WTF
-					size_t end = npoint + maxpoints;
-					if(end > npoints)
-						end = npoints;
-					m_transport->SendCommandQueued(
-						string("WAV:STOP ") + to_string(end));	  //Here it is zero based, so it gets from 1-1000
-		
-					//Ask for the data block
+					m_transport->SendCommandQueued("*WAI");
+					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint+1));	//ONE based indexing WTF
+					m_transport->SendCommandQueued(string("WAV:STOP ") + to_string(min(npoint + maxpoints, npoints)));
 					m_transport->SendCommandQueued("WAV:DATA?");
 					break;
-				}
 
 				case Series::UNKNOWN:
 					LogError("RigolOscilloscope: unknown model, invalid state!\n");
@@ -2307,37 +2283,13 @@ bool RigolOscilloscope::AcquireData()
 				break;
 				
 				case Series::MSODS1000Z:
-				{
-					// specify block sample range
-					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint+1));	//ONE based indexing WTF
-					m_transport->SendCommandQueued(string("WAV:STOP ") + to_string(min(npoint + maxpoints, npoints)));	//Here it is zero based, so it gets from 1-1000
-					// m_transport->SendCommandQueued("*WAI"); // looks unnecessary
-
-					//Ask for the data block
-					m_transport->SendCommandQueued("WAV:DATA?");
-				} break;
-
-				
 				case Series::MSO5000:
-					//Ask for the data block
-					m_transport->SendCommandQueued("*WAI");
-					m_transport->SendCommandQueued("WAV:DATA?");
-					break;
-					
 				case Series::DHO900:
-				{
-					//Ask for the data
-					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint + 1));	//ONE based indexing WTF
-					size_t end = npoint + maxpoints;
-					if(end > npoints)
-						end = npoints;
-					m_transport->SendCommandQueued(
-						string("WAV:STOP ") + to_string(end));	  //Here it is zero based, so it gets from 1-1000
-						
-					//Ask for the data block
+					m_transport->SendCommandQueued("*WAI");
+					m_transport->SendCommandQueued(string("WAV:STAR ") + to_string(npoint+1));
+					m_transport->SendCommandQueued(string("WAV:STOP ") + to_string(min(npoint + maxpoints, npoints)));
 					m_transport->SendCommandQueued("WAV:DATA?");
-					break;
-				}
+				break;
 				
 				case Series::DHO1000:
 				case Series::DHO4000:

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -41,6 +41,11 @@
 #include <thread>
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wswitch"
+// #pragma GCC diagnostic warning "-Wswitch-enum"
+
+
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2310,3 +2315,5 @@ void RigolOscilloscope::ForceHDMode(bool mode)
 			break;
 	}
 }
+
+#pragma GCC diagnostic pop

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -575,7 +575,7 @@ void RigolOscilloscope::UpdateDynamicCapabilities() {
 			vector<std::uint64_t> depths;
 			for (auto &depth : ds1000zSampleDepths)
 			{
-				if (depth == 24'000'000 and (not m_opt24M or divisor != 1))
+				if (depth == 24'000'000 and (not m_opt24M))
 					continue;
 
 				depths.emplace_back(depth/divisor);

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2204,7 +2204,7 @@ bool RigolOscilloscope::AcquireData()
 		}
 
 		auto ts_channel_download_end = chrono::steady_clock::now();
-		LogTrace("Channel %s download took %ld ms\n", GetChannel(channelIdx)->GetDisplayName().c_str(), chrono::duration_cast<chrono::milliseconds>(ts_channel_download_end - ts_channel_download_start).count());
+		LogTrace("Channel %s download took %" PRIi64 " ms\n", GetChannel(channelIdx)->GetDisplayName().c_str(), int64_t(chrono::duration_cast<chrono::milliseconds>(ts_channel_download_end - ts_channel_download_start).count()));
 
 		// Notify about end of download for this channel
 		ChannelsDownloadStatusUpdate(channelIdx, InstrumentChannel::DownloadState::DOWNLOAD_FINISHED, 1.0);
@@ -2436,7 +2436,7 @@ bool RigolOscilloscope::AcquireData()
 		}
 
 		auto ts_bank_download_end = chrono::steady_clock::now();
-		LogTrace("Digital bank %zd download took %ld ms\n", bankIdx, chrono::duration_cast<chrono::milliseconds>(ts_bank_download_end - ts_bank_download_start).count());
+		LogTrace("Digital bank %zd download took %" PRIi64 " ms\n", bankIdx, int64_t(chrono::duration_cast<chrono::milliseconds>(ts_bank_download_end - ts_bank_download_start).count()));
 
 		// download finished
 		for (auto& channel : bankChannels)
@@ -2460,7 +2460,7 @@ bool RigolOscilloscope::AcquireData()
 	}
 
 	auto ts_download_end = chrono::steady_clock::now();
-	LogTrace("Whole download took %ld ms\n", chrono::duration_cast<chrono::milliseconds>(ts_download_end - ts_download_start).count());
+	LogTrace("Whole download took %" PRIi64 " ms\n", int64_t(chrono::duration_cast<chrono::milliseconds>(ts_download_end - ts_download_start).count()));
 
 	//Now that we have all of the pending waveforms, save them in sets across all channels
 	{
@@ -3205,7 +3205,7 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 		case Series::MSO5000:
 		{
 			//TODO: consoder defining available time scales and do lookup of closes one (equal or lower) then we get from formula
-			LogTrace("setting target samplerate %lu\n", rate);
+			LogTrace("setting target samplerate %" PRIu64 "\n", rate);
 			switch (rate)
 			{
 				// 4 Gpss result in 25 us, but the scope's native step is 20 us, anything above results in 

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2154,6 +2154,11 @@ void RigolOscilloscope::SetTriggerOffset(int64_t offset)
 		offset = width_fs; // we want to ensure, the trigger is inside the capture range 0~mdepth
 	m_transport->SendCommandQueued(string(":TIM:MAIN:OFFS ") + to_string((halfwidth_fs - offset) * SECONDS_PER_FS));
 
+	{
+		lock_guard<recursive_mutex> lock(m_cacheMutex);
+		m_triggerOffsetValid = false;
+	}
+
 }
 
 int64_t RigolOscilloscope::GetTriggerOffset()

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2977,8 +2977,13 @@ uint64_t RigolOscilloscope::GetSampleDepth()
 			auto const depth = parseU64(depth_str);
 			if (depth)
 				return *depth;
-			LogError("could not sampled depth from %s. Falling back to lowest one\n", depth_str.c_str());
-			
+			LogError("could not parse sampled depth from %s. Falling back to lowest one\n", depth_str.c_str());
+			auto depths = GetSampleDepthsNonInterleaved();
+			if (depths.empty())
+			{
+				LogError("no known sampled depths known!\n");
+				return 0;
+			}
 			SetSampleDepth(GetSampleDepthsNonInterleaved()[0]);
 		}
 		return 0;

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -222,6 +222,23 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 		case Series::UNKNOWN:
 			break;
 	}
+
+	// disable auto roll mode on DHOs
+	switch (m_series) {
+		case Series::DHO1000:
+		case Series::DHO4000:
+		case Series::DHO800:
+		case Series::DHO900:
+			m_transport->SendCommandQueued(":TIM:ROLL 0");
+			break;
+
+		case Series::DS1000:
+		case Series::MSODS1000Z:
+		case Series::MSO5000:
+		case Series::UNKNOWN:
+			break;
+	}
+	
 	
 	for(size_t i = 0; i < m_analogChannelCount; i++)
 		m_transport->SendCommandQueued(":" + m_channels[i]->GetHwname() + ":VERN ON");

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -32,9 +32,6 @@
 #include "EdgeTrigger.h"
 
 #include <cinttypes>
-#include <cstdint>
-#include <memory>
-#include <string>
 
 #ifdef _WIN32
 #include <chrono>

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2150,6 +2150,8 @@ void RigolOscilloscope::SetTriggerOffset(int64_t offset)
 	auto depth = GetSampleDepth();
 	auto width_fs = static_cast<int64_t>(round(FS_PER_SECOND * depth / rate));
 	auto halfwidth_fs = width_fs /2;
+	if (offset > width_fs)
+		offset = width_fs; // we want to ensure, the trigger is inside the capture range 0~mdepth
 	m_transport->SendCommandQueued(string(":TIM:MAIN:OFFS ") + to_string((halfwidth_fs - offset) * SECONDS_PER_FS));
 
 }

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2313,7 +2313,6 @@ void RigolOscilloscope::SetTriggerOffset(int64_t offset)
 
 int64_t RigolOscilloscope::GetTriggerOffset()
 {
-	//Early out if the value is in cache
 	{
 		lock_guard<recursive_mutex> lock(m_cacheMutex);
 		if(m_triggerOffsetValid)

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -92,7 +92,6 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 	LogTrace("RigolOscilloscope: series: %d\n", int(m_series));
 
 	AnalyzeDeviceCapabilities();
-	UpdateDynamicCapabilities();
 
 	for(auto i = 0U; i < m_analogChannelCount; i++)
 	{
@@ -172,7 +171,8 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 	}
 
 	FlushConfigCache();
-
+	
+	UpdateDynamicCapabilities();
 	//make sure all setup commands finish before we proceed
 	m_transport->FlushCommandQueue();
 }

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -2140,6 +2140,12 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 	//TODO: should we also protect these with mutex?
 	m_srateValid = false;
 	m_mdepthValid = false;
+	// To prevent trigger offset travelling on Srate change (timebase change),
+	// re-set trigger location, because difference (time) between
+	// our trigger reference point (start of sample buffer) and
+	// scope trigger reference point (mid of the sample buffer) changed.
+	SetTriggerOffset(m_triggerOffset);
+	
 }
 
 void RigolOscilloscope::SetTriggerOffset(int64_t offset)

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -1711,8 +1711,7 @@ void RigolOscilloscope::SetChannelVoltageRange(size_t i, size_t /*stream*/, floa
 
 OscilloscopeChannel* RigolOscilloscope::GetExternalTrigger()
 {
-	//FIXME
-	return nullptr;
+	return m_extTrigChannel;
 }
 
 float RigolOscilloscope::GetChannelOffset(size_t i, size_t /*stream*/)

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -205,7 +205,8 @@ RigolOscilloscope::RigolOscilloscope(SCPITransport* transport)
 	//Configure acquisition modes
 	switch (m_series) {
 		case Series::DS1000:
-			m_transport->SendCommandQueued(":WAV:POIN:MODE RAW");
+			// m_transport->SendCommandQueued(":WAV:POIN:MODE RAW");
+			// this command is not listed anywhere in the docs
 			break;
 		
 		case Series::MSODS1000Z:
@@ -362,6 +363,7 @@ void RigolOscilloscope::AnalyzeDeviceCapabilities() {
 		case Series::DS1000:
 			m_analogChannelCount = m_modelNew.number % 10;
 			m_bandwidth = m_modelNew.number % 1000 - m_analogChannelCount;
+			//TODO:  there are DS1000D devices with LA
 			break;
 
 		case Series::MSODS1000Z:
@@ -1052,6 +1054,8 @@ bool RigolOscilloscope::IsChannelEnabled(size_t i)
 	if (IsChannelAnalog(i))
 	{
 		auto reply = Trim(m_transport->SendCommandQueuedWithReply(":" + m_channels[i]->GetHwname() + ":DISP?"));
+		// FIXME: DS1000E response times out, not sure why, prog. manual lists this command
+		// could be caused by some malformed command before
 	
 		{
 			lock_guard<recursive_mutex> lock(m_cacheMutex);

--- a/scopehal/RigolOscilloscope.cpp
+++ b/scopehal/RigolOscilloscope.cpp
@@ -3167,20 +3167,17 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 {
 	// Rigol scopes do not have samplerate controls. Only timebase can be adjusted :TIMebase:SCALe
 	{
-		lock_guard<recursive_mutex> lock(m_cacheMutex);
-		m_mdepth.reset();
-
 		bool requestedValueisValid {};
 		auto rates = GetSampleRatesNonInterleaved();
-		for (auto const& depth : rates)
-			if (depth == rate)
+		for (auto const& rate_item : rates)
+			if (rate_item == rate)
 			{
 				requestedValueisValid = true;
 				break;
 			}
 		if (not requestedValueisValid)
 		{
-			LogWarning("requested sample rate %" PRIu64 " is not any of %zd of suported by this device\n", rate, rates.size());
+			LogWarning("requested sample rate %" PRIu64 " is not any of %zd of supported by this device\n", rate, rates.size());
 			return;
 		}
 	}
@@ -3233,6 +3230,11 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 					break;
 				
 			}
+			{
+				// TODO: is is really necessary to reset cached sample depth value?
+				lock_guard<recursive_mutex> lock(m_cacheMutex);
+				m_mdepth.reset();
+			}
 			SetSampleDepth(GetSampleDepth()); // see note at MSODO1000Z
 			break;
 		}
@@ -3261,6 +3263,11 @@ void RigolOscilloscope::SetSampleRate(uint64_t rate)
 			// Another requirement is that this read has to happen after the acquisition finishes which could take a long time on samplerates
 			// (this is visible even when you operate the scope manually)
 			// Workaround to both is to (re-)write memory depth, don't ask me why.
+			{
+				// TODO: is is really necessary to reset cached sample depth value?
+				lock_guard<recursive_mutex> lock(m_cacheMutex);
+				m_mdepth.reset();
+			}
 			SetSampleDepth(GetSampleDepth());
 			break;
 		}

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -51,6 +51,7 @@ public:
 
 	//Channel configuration
 	virtual bool IsChannelEnabled(size_t i) override;
+	virtual bool CanEnableChannel(size_t i) override;
 	virtual void EnableChannel(size_t i) override;
 	virtual void DisableChannel(size_t i) override;
 	virtual OscilloscopeChannel::CouplingType GetChannelCoupling(size_t i) override;
@@ -173,6 +174,11 @@ protected:
 	bool IsChannelDigital(std::size_t i);
 	std::uint64_t GetPendingWaveformBlockLength(); // extratcs waveform block size from the TMC header at beginnign of each response to :WAV:DATA? command
 	void LogLaNotPresent();
+	std::size_t IdxToAnalogChannelNumber(std::size_t i); // does not check for validity!
+	std::size_t AnalogChannelNumberToIdx(std::size_t i); // does not check for validity!
+	std::size_t IdxToDigitalChannelNumber(std::size_t i); // does not check for validity!
+	std::size_t DigitalChannelNumberToIdx(std::size_t i); // does not check for validity!
+	std::size_t IdxToDigitalBankIdx(std::size_t i); // does not check for validity!
 
 protected:
 	OscilloscopeChannel* m_extTrigChannel;

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -126,7 +126,7 @@ protected:
 
 	enum class CaptureFormat : int {
 		BYTE_ = 0, // a waveform point occupies one byte (namely 8 bits). Suffix _ because msys64/ucrt64/include/minwindef.h defines BYTE as char :facepalm:
-		WORD = 1, // a waveform point occupies two bytes (namely 16 bits) in which the lower 8 bits are valid and the higher 8 bits are 0.
+		WORD_ = 1, // a waveform point occupies two bytes (namely 16 bits) in which the lower 8 bits are valid and the higher 8 bits are 0. Suffix _ because msys64/ucrt64/include/minwindef.h defines BYTE as char :facepalm:
 		ASC = 2   // waveform points in character number. Waveform points are returned in scientific notation and separated by commas./
 	};
 

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -125,7 +125,7 @@ protected:
 	};
 
 	enum class CaptureFormat : int {
-		BYTE = 0, // a waveform point occupies one byte (namely 8 bits).
+		BYTE_ = 0, // a waveform point occupies one byte (namely 8 bits). Suffix _ because msys64/ucrt64/include/minwindef.h defines BYTE as char :facepalm:
 		WORD = 1, // a waveform point occupies two bytes (namely 16 bits) in which the lower 8 bits are valid and the higher 8 bits are 0.
 		ASC = 2   // waveform points in character number. Waveform points are returned in scientific notation and separated by commas./
 	};

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -229,6 +229,7 @@ protected:
 	Series m_series;
 
 	//True if we have >8 bit capture depth
+	//TODO: switch to GetADCMode/SetADCMode API instead of having custom attribute switching DHOs to 12 bits
 	bool m_highDefinition;
 
 	void PushEdgeTrigger(EdgeTrigger* trig);

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -193,12 +193,9 @@ protected:
 	std::map<size_t, float> m_bankThresholds;
 	std::map<int, bool> m_channelsEnabled;
 	std::vector<std::uint64_t> m_depths;
-	bool m_srateValid;
-	uint64_t m_srate;
-	bool m_mdepthValid;
-	uint64_t m_mdepth;
-	int64_t m_triggerOffset;
-	bool m_triggerOffsetValid;
+	std::optional<uint64_t> m_srate;
+	std::optional<uint64_t> m_mdepth;
+	std::optional<int64_t> m_triggerOffset;
 	std::optional<bool> m_laEnabled;
 
 	// state variables, may alter values during runtime

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -170,6 +170,7 @@ protected:
 	void AnalyzeDeviceCapabilities();
 	void UpdateDynamicCapabilities(); // capabilities dependent on enabled chanel count
 	std::size_t GetMsods1000ZChannelDivisor(); // helper function to get memory depth/sample rate divisor base on current scope state (amount of enabled channels)
+	std::array<std::size_t, 2> GetMso5000AnalogBankUsage();
 	bool IsChannelAnalog(std::size_t i);
 	bool IsChannelDigital(std::size_t i);
 	std::uint64_t GetPendingWaveformBlockLength(); // extratcs waveform block size from the TMC header at beginnign of each response to :WAV:DATA? command

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -104,7 +104,7 @@ protected:
 		UNKNOWN,
 
 		DS1000,
-		DS1000Z,
+		MSODS1000Z,
 		// MSODS2000,
 		// MSO4000,
 		MSO5000,

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -181,7 +181,7 @@ protected:
 	std::size_t IdxToDigitalBankIdx(std::size_t i); // does not check for validity!
 
 protected:
-	OscilloscopeChannel* m_extTrigChannel;
+	OscilloscopeChannel* m_extTrigChannel {};
 
 	// hardware analog channel count, independent of LA option etc
 	size_t m_analogChannelCount;

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -186,9 +186,9 @@ protected:
 	OscilloscopeChannel* m_aclTrigChannel {}; // TODO: scopehal does not handle AC "external triggers" ATM
 
 	// hardware analog channel count, independent of LA option etc
-	size_t m_analogChannelCount;
+	size_t m_analogChannelCount {};
 
-	size_t m_digitalChannelCount;
+	size_t m_digitalChannelCount {};
 	std::vector<Oscilloscope::DigitalBank> m_digitalBanks;
 
 	// config cache, values that can be updated whenever needed
@@ -207,12 +207,12 @@ protected:
 	std::optional<bool> m_laEnabled;
 
 	// state variables, may alter values during runtime
-	bool m_triggerArmed;
-	bool m_triggerWasLive;
-	bool m_triggerOneShot;
-	std::uint_least32_t m_pointsWhenStarted; // used for some series as a part of trigger state detection workaround, sampled points reported right after arming
+	bool m_triggerArmed {};
+	bool m_triggerWasLive {};
+	bool m_triggerOneShot {};
+	std::uint_least32_t m_pointsWhenStarted {}; // used for some series as a part of trigger state detection workaround, sampled points reported right after arming
 
-	bool m_liveMode;
+	bool m_liveMode {};
 
 	// constants once the ctor finishes
 	struct Model {
@@ -221,7 +221,7 @@ protected:
 		std::string suffix; // e.g.: Z
 	} m_modelNew;
 	
-	unsigned int m_bandwidth;
+	unsigned int m_bandwidth {};
 	bool m_opt200M {}; // 200M memory depth is MSO5000 specific option 
 	bool m_opt24M {};  // 24M memory depth is DS1000Z specific option 
 	uint64_t m_maxMdepth {}; // Maximum Memory depth for DHO models

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -98,6 +98,7 @@ public:
 	void ForceHDMode(bool mode);
 
 protected:
+	// private/internal types and functions
 	enum class Series
 	{
 		UNKNOWN,
@@ -155,16 +156,18 @@ protected:
 protected:
 	OscilloscopeChannel* m_extTrigChannel;
 
-	//hardware analog channel count, independent of LA option etc
+	// hardware analog channel count, independent of LA option etc
 	size_t m_analogChannelCount;
 
-	//config cache
+	// config cache, values that can be updated whenever needed
+	// all access to these shall be exclusive using `m_cacheMutex`
 	std::map<size_t, double> m_channelAttenuations;
 	std::map<size_t, OscilloscopeChannel::CouplingType> m_channelCouplings;
 	std::map<size_t, float> m_channelOffsets;
 	std::map<size_t, float> m_channelVoltageRanges;
 	std::map<size_t, unsigned int> m_channelBandwidthLimits;
 	std::map<int, bool> m_channelsEnabled;
+	std::vector<std::uint64_t> m_depths;
 	bool m_srateValid;
 	uint64_t m_srate;
 	bool m_mdepthValid;
@@ -172,6 +175,7 @@ protected:
 	int64_t m_triggerOffset;
 	bool m_triggerOffsetValid;
 
+	// state variables, may alter values during runtime
 	bool m_triggerArmed;
 	bool m_triggerWasLive;
 	bool m_triggerOneShot;
@@ -179,6 +183,7 @@ protected:
 
 	bool m_liveMode;
 
+	// constants once the ctor finishes
 	struct Model {
 		std::string prefix; // e.g.: DS
 		unsigned int number; // e.g.: 1054
@@ -192,15 +197,12 @@ protected:
 	uint64_t m_maxSrate {};  // Maximum Sample rate for DHO models
 	bool m_lowSrate {};	  // True for DHO low sample rate models (DHO800/900)
 	Series m_series;
-	// protocol_version m_protocol;
 
 	//True if we have >8 bit capture depth
 	bool m_highDefinition;
 
 	void PushEdgeTrigger(EdgeTrigger* trig);
 	void PullEdgeTrigger();
-
-	std::vector<std::uint64_t> m_depths;
 
 public:
 	static std::string GetDriverNameInternal();

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -182,6 +182,7 @@ protected:
 
 protected:
 	OscilloscopeChannel* m_extTrigChannel {};
+	OscilloscopeChannel* m_aclTrigChannel {}; // TODO: scopehal does not handle AC "external triggers" ATM
 
 	// hardware analog channel count, independent of LA option etc
 	size_t m_analogChannelCount;

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -130,8 +130,29 @@ protected:
 		// NOTE: If the MATH channel is selected, only the NORMal mode is valid.
 	};
 
+
+	struct CapturePreamble {
+		CaptureFormat format;
+		CaptureType type;
+		std::uint_least32_t npoints; // an integer between 1 and 12000000.
+		std::uint_least32_t averages; // the number of averages in the average sample mode and 1 in other modes.
+		double sec_per_sample; // the time difference between two neighboring points in the X direction.
+		double xorigin; // the time from the trigger point to the "Reference Time" in the X direction.
+		double xreference; // the reference time of the data point in the X direction.
+		double yincrement; // the waveform increment in the Y direction.
+		double yorigin; // the vertical offset relative to the "Vertical Reference Position" in the Y direction.
+		double yreference; // the vertical reference position in the Y direction.
+	};
+
+	std::optional<CapturePreamble> GetCapturePreamble();
 	void StartPre();
 	void StartPost();
+	void DecodeDeviceSeries();
+	void AnalyzeDeviceCapabilities();
+	void UpdateDynamicCapabilities(); // capabilities dependent on enabled chanel count
+	std::size_t GetChannelDivisor(); // helper function to get memory depth/sample rate divisor base on current scope state (amount of enabled channels)
+
+protected:
 	OscilloscopeChannel* m_extTrigChannel;
 
 	//hardware analog channel count, independent of LA option etc
@@ -154,6 +175,7 @@ protected:
 	bool m_triggerArmed;
 	bool m_triggerWasLive;
 	bool m_triggerOneShot;
+	std::uint_least32_t m_pointsWhenStarted; // used for some series as a part of trigger state detection workaround, sampled points reported right after arming
 
 	bool m_liveMode;
 
@@ -178,26 +200,7 @@ protected:
 	void PushEdgeTrigger(EdgeTrigger* trig);
 	void PullEdgeTrigger();
 
-	struct CapturePreamble {
-		CaptureFormat format;
-		CaptureType type;
-		std::size_t npoints; // an integer between 1 and 12000000.
-		std::size_t averages; // the number of averages in the average sample mode and 1 in other modes.
-		double sec_per_sample; // the time difference between two neighboring points in the X direction.
-		double xorigin; // the time from the trigger point to the "Reference Time" in the X direction.
-		double xreference; // the reference time of the data point in the X direction.
-		double yincrement; // the waveform increment in the Y direction.
-		double yorigin; // the vertical offset relative to the "Vertical Reference Position" in the Y direction.
-		double yreference; // the vertical reference position in the Y direction.
-	};
 	std::vector<std::uint64_t> m_depths;
-
-	std::optional<CapturePreamble> GetCapturePreamble();
-	void PrepareStart();
-	void DecodeDeviceSeries();
-	void AnalyzeDeviceCapabilities();
-	void UpdateDynamicCapabilities(); // capabilities dependent on enabled chanel count
-	std::size_t GetChannelDivisor(); // helper function to get memory depth/sample rate divisor base on current scope state (amount of enabled channels)
 
 public:
 	static std::string GetDriverNameInternal();

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -169,7 +169,7 @@ protected:
 	void DecodeDeviceSeries();
 	void AnalyzeDeviceCapabilities();
 	void UpdateDynamicCapabilities(); // capabilities dependent on enabled chanel count
-	std::size_t GetChannelDivisor(); // helper function to get memory depth/sample rate divisor base on current scope state (amount of enabled channels)
+	std::size_t GetMsods1000ZChannelDivisor(); // helper function to get memory depth/sample rate divisor base on current scope state (amount of enabled channels)
 	bool IsChannelAnalog(std::size_t i);
 	bool IsChannelDigital(std::size_t i);
 	std::uint64_t GetPendingWaveformBlockLength(); // extratcs waveform block size from the TMC header at beginnign of each response to :WAV:DATA? command

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -130,6 +130,8 @@ protected:
 		// NOTE: If the MATH channel is selected, only the NORMal mode is valid.
 	};
 
+	void StartPre();
+	void StartPost();
 	OscilloscopeChannel* m_extTrigChannel;
 
 	//hardware analog channel count, independent of LA option etc

--- a/scopehal/RigolOscilloscope.h
+++ b/scopehal/RigolOscilloscope.h
@@ -151,16 +151,16 @@ protected:
 	std::size_t GetEnabledAnalogChannelCount();
 
 	struct CapturePreamble {
-		CaptureFormat format;
-		CaptureType type;
-		std::uint_least32_t npoints; // an integer between 1 and 12000000.
-		std::uint_least32_t averages; // the number of averages in the average sample mode and 1 in other modes.
-		double sec_per_sample; // the time difference between two neighboring points in the X direction.
-		double xorigin; // the time from the trigger point to the "Reference Time" in the X direction.
-		double xreference; // the reference time of the data point in the X direction.
-		double yincrement; // the waveform increment in the Y direction.
-		double yorigin; // the vertical offset relative to the "Vertical Reference Position" in the Y direction.
-		double yreference; // the vertical reference position in the Y direction.
+		CaptureFormat format {};
+		CaptureType type {};
+		std::uint_least32_t npoints {}; // an integer between 1 and 12000000.
+		std::uint_least32_t averages {}; // the number of averages in the average sample mode and 1 in other modes.
+		double sec_per_sample {}; // the time difference between two neighboring points in the X direction.
+		double xorigin {}; // the time from the trigger point to the "Reference Time" in the X direction.
+		double xreference {}; // the reference time of the data point in the X direction.
+		double yincrement {}; // the waveform increment in the Y direction.
+		double yorigin {}; // the vertical offset relative to the "Vertical Reference Position" in the Y direction.
+		double yreference {}; // the vertical reference position in the Y direction.
 	};
 
 	std::optional<CapturePreamble> GetCapturePreamble();


### PR DESCRIPTION
This is a Rigol Oscilloscope driver refactor.
Related issues #943

**I need testers for most scope families (see below).**

## Refactor
- each family has it's own identifier and can be easily handled individually
- use STL containers instead of plain C arrays
- use RAII for safe(r) resource management

## Supported devices and new features
- DS1000: Broken  :negative_squared_cross_mark: 
  - times out on some commands and FW crashes, needs more investigation
- MSO/DS1000Z: tested :heavy_check_mark:  (DS1054Z with all options, MSO1104Z with all options)
  - LA: :heavy_check_mark: (MSO1000Z only)
  - implemented memory/samplerate configuration: :heavy_check_mark:
  - improved download speed: :heavy_check_mark:
  - improved trigger poll performance/robustness: :heavy_check_mark:
- MSO5000: fixed trigger polling, added LA support
  - analog, samplerate control, triggering, polling, data acq.: :heavy_check_mark:
  - LA: :heavy_check_mark:
- DHO800:
  - analog, samplerate control, triggering, polling, data acq.: :heavy_check_mark:
  - switched download to single block, doubled the download speed
- DHO900: no intended changes, but untested (I can borrow one to validate my changes) :pray:
  - should be the same as DHO800
  - LA: untested
- DHO1000: no intended changes, but untested :pray: 
- DHO4000: no intended changes, but untested :pray:

## Known issues (TBD):
- Memory depth does not update (in ngscopesclient)  when channels are added to the capture. https://github.com/ngscopeclient/scopehal-apps/issues/920
- MSO5000 trigger detection is unreliable  (on 8 gs/s we may completely miss the non "STOP" state)
- Driver uses it's own sample conversion function, instead of [one from core](https://github.com/ngscopeclient/scopehal/issues/1035#issuecomment-3700530441)  
- use `SetADCMode`/`GetADCMode` for devices which support multiple sample resolutions (at least DHOs - those current use custom settings property)

## non device specific
- Some trigger offset fixes (keep in place and in valid range on samplerate/memory depthy changes)

### Triggers
- Pulse width: WIP (#1019)

## Not _yet_ supported devices
- MSO/DS2000: not supported yet
- MSO/DS4000: not supported yet (I have access to this device and can work on the support)
- MHO900/MHO098: not supported yet, device available via network (#1022)