### PR TITLE
Extend 10Base-T decoder to catch wide eye at the beginning of the preamble of TX frames

### DIFF
--- a/scopeprotocols/Ethernet10BaseTDecoder.cpp
+++ b/scopeprotocols/Ethernet10BaseTDecoder.cpp
@@ -93,6 +93,8 @@ void Ethernet10BaseTDecoder::Refresh(
 
 	const int64_t eye_start = ui_halfwidth - jitter_tol;
 	const int64_t eye_end = ui_halfwidth + jitter_tol;
+	const int64_t eye_wide_start = ui_width - jitter_tol;
+	const int64_t eye_wide_end = ui_width + jitter_tol;
 
 	size_t i = 0;
 	bool done = false;
@@ -150,7 +152,11 @@ void Ethernet10BaseTDecoder::Refresh(
 				i++;
 				break;
 			}
-			if( (delta < eye_start) || (delta > eye_end) )
+			// Normal eye for first bit in RX frame (from the network)
+			bool in_normal_eye = (delta >= eye_start) && (delta <= eye_end);
+			// Wide eye for first bit in TX frame (from the NIC)
+			bool in_wide_eye = (delta >= eye_wide_start) && (delta <= eye_wide_end);
+			if(!in_normal_eye && !in_wide_eye)
 			{
 				LogTrace("Edge was in the wrong place, skipping it and attempting resync\n");
 				i++;


### PR DESCRIPTION
**Fix for issue:**
Ethernet10BaseTDecoder expects frames to begin with a falling edge. In some cases TX frames (from the host computer to the network) begin with a positive edge.
Also, in these cases, the first zero crossing is 100ns long instead of the 50ns we see in RX frames.
This causes the decoder to not decode TX frames.

**Debug log of the issue:**
```
[Ethernet10BaseTDecoder::Refresh]     Start of frame
    [T = 799983.000 ns] Found initial falling edge
[Ethernet10BaseTDecoder::Refresh]     Edge was in the wrong place, skipping it and attempting resync
[Ethernet10BaseTDecoder::Refresh]     Edge was in the wrong place, skipping it and attempting resync
[Ethernet10BaseTDecoder::Refresh]     Edge was in the wrong place, skipping it and attempting resync
...
...
...
[Ethernet10BaseTDecoder::Refresh]     Edge was in the wrong place, skipping it and attempting resync
[Ethernet10BaseTDecoder::Refresh]     Capture ended while looking for end of this bit
```

**Beginning of the 10Base-T transmission frame:**
![10baset-tx-frame-example](https://juan-domenech.github.io/10baset-tx-frame-example.png)

**Proposed solution:**
- Create 2 new constants for a Full Width eye
- Extend the "Edge was in the wrong place" range condition to make valid both cases: 50ns and 100ns length

This has been tested using Ethernet 10Mbits hardware and waveforms from a Rigol oscillloscope.

Additional context on this Youtube ▶️ video: [
Exploring Ethernet: Decoding 10BASE-T (success!)](https://www.youtube.com/watch?v=5ghgLt0WJCY)